### PR TITLE
Do not require singing

### DIFF
--- a/main/bin/entrypoint.sh
+++ b/main/bin/entrypoint.sh
@@ -9,7 +9,7 @@ echo "BUILD=$BUILD"
 
 jfrog rt config repox --url https://repox.jfrog.io/artifactory/ --apikey "$ARTIFACTORY_API_KEY" --basic-auth-only
 cd "$(mktemp -d sigcheck.XXXXXXXXXX)" && {
-  jfrog rt download --fail-no-op --build "${BUILD}" sonarsource-builds/**/*.asc
+  jfrog rt download --build "${BUILD}" sonarsource-builds/**/*.asc
   find . -type f -name "*.asc" -exec gpg --list-packets {} \; | grep ${REVOKED_KEY} && exit 1 || true
 }
 


### PR DESCRIPTION
If no signature can be downloaded, continue without breaking the pipeline.