### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
           RELEASE_SSH_USER: ${{ secrets.RELEASE_SSH_USER }}
           RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
-        uses: SonarSource/gh-action_release/main@4.2.0
+        uses: SonarSource/gh-action_release/main@v4
         with:
           publish_to_binaries: true # Used only if the binaries is delivered to costumers
           slack_channel: builders-guild
@@ -65,14 +65,14 @@ jobs:
         id: local_repo
         run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@4.0.1
+        uses: SonarSource/gh-action_release/download-build@v4
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@4.0.1
+        uses: SonarSource/gh-action_release/maven-central-sync@v4
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:


### PR DESCRIPTION
Based on the latest comments [here](https://discuss.sonarsource.com/t/legacy-binaries-cutover/9960/4), I think this could be updated to the following, though I'm not sure the `v4` shortcut is available for the `download-build` & `maven-central-sync` gh actions. Let me know.