### PR TITLE
 BUILD-1732 Refactor the GitHub class

### DIFF
--- a/main/Pipfile
+++ b/main/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pytest = "*"
 pytest-cov = "*"
 
 [packages]

--- a/main/Pipfile
+++ b/main/Pipfile
@@ -14,4 +14,4 @@ slack_sdk = "*"
 boto3 = "*"
 
 [requires]
-python_version = "3"
+python_version = "3.10"

--- a/main/Pipfile.lock
+++ b/main/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "89348173ccc395eac8a69fae919867a3eb1f18b0ce50353cce92176857531680"
+            "sha256": "ab70b94b17cdad225dadbea6b46cf18543953f6a065a74594b9e879cb207e9c0"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:375f3276f257d1b7be8b3101427778e4e865a06ba35d3853d619b5559895a07a",
-                "sha256:ddfb72c3a24b58fde7050525f7939166816c0911196abc0d66c9d34ee26d9717"
+                "sha256:626bbec91ca2423e427636db207a03c854b52d22715c9b34a953ee8260817f6f",
+                "sha256:7e0a5c86059866d7f9e27d6574da9bfb4f8a03c4caf055724145f3cd44785b81"
             ],
             "index": "pypi",
-            "version": "==1.24.24"
+            "version": "==1.24.27"
         },
         "botocore": {
             "hashes": [
-                "sha256:18227ab1c4646f54cd5deb8cdf6f096ce9867b2354416f6becaea45bb12c028a",
-                "sha256:e3038a19cc442c16bdf05afd34a2b7717b3fe2ed50b3847472eb9e730cf4691a"
+                "sha256:524da451350c41e3136353183e7424c95952124163ea8ec03f57f29597bbcb4b",
+                "sha256:583b85f8a799fb89d1a762db041163b5848b08e79cee06b609bcaaeb69ea1fa6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.24"
+            "version": "==1.27.27"
         },
         "certifi": {
             "hashes": [
@@ -113,11 +113,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
-                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
+                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.10"
         }
     },
     "develop": {

--- a/main/Pipfile.lock
+++ b/main/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f72a06d016765a6005ee6e4eced164eda34b70680ef4c5956659fa088c01d917"
+            "sha256": "89348173ccc395eac8a69fae919867a3eb1f18b0ce50353cce92176857531680"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:25d0e3bce0d8bb79d15ff5018af5867bbaef25e0aa20d21a1d616e8c754127c7",
-                "sha256:5d3b8c5b84f38f9c24dd4330f36a796a2dedc8289c427e830e939ba6e7a41ccc"
+                "sha256:375f3276f257d1b7be8b3101427778e4e865a06ba35d3853d619b5559895a07a",
+                "sha256:ddfb72c3a24b58fde7050525f7939166816c0911196abc0d66c9d34ee26d9717"
             ],
             "index": "pypi",
-            "version": "==1.24.23"
+            "version": "==1.24.24"
         },
         "botocore": {
             "hashes": [
-                "sha256:2536f1c416b7a3e27cb012b9fad052cd991eb7d17bbaa4ca1702a4ee0d964014",
-                "sha256:4581f80de78147cb32333aae1bd8d0842360a85138221dd5c79b48eab72d5f99"
+                "sha256:18227ab1c4646f54cd5deb8cdf6f096ce9867b2354416f6becaea45bb12c028a",
+                "sha256:e3038a19cc442c16bdf05afd34a2b7717b3fe2ed50b3847472eb9e730cf4691a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.23"
+            "version": "==1.27.24"
         },
         "certifi": {
             "hashes": [
@@ -76,7 +76,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "requests": {
@@ -100,7 +100,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "slack-sdk": {
@@ -223,7 +223,7 @@
                 "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
                 "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
             ],
-            "markers": "python_version >= '3.7'",
+            "index": "pypi",
             "version": "==7.1.2"
         },
         "pytest-cov": {
@@ -239,6 +239,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         }
     }

--- a/main/release/steps/ReleaseRequest.py
+++ b/main/release/steps/ReleaseRequest.py
@@ -1,7 +1,8 @@
 class ReleaseRequest:
-    def __init__(self, org, project, buildnumber, branch, sha):
+    def __init__(self, org, project, version, buildnumber, branch, sha):
         self.org = org
         self.project = project
+        self.version = version
         self.buildnumber = buildnumber
         self.branch = branch
         self.sha = sha

--- a/main/release/utils/burgr.py
+++ b/main/release/utils/burgr.py
@@ -74,12 +74,8 @@ class Burgr:
         if r.status_code != 201:
             print(f"burgr notification failed code:{r.status_code}")
 
-    def start_releasability_checks(self, version: str):
-        r"""Starts the releasability check operation. Post the start releasability HTTP request to Burgrx.
-
-        :param version: full version to be checked for releasability.
-        """
-
+    def start_releasability_checks(self):
+        version = self.release_request.version
         print(f"Starting releasability check: {self.release_request.project}#{version}")
 
         # SLVSCODE-specific
@@ -96,14 +92,12 @@ class Burgr:
             raise Exception(f"Releasability checks failed to start: '{message}'")
 
     def get_releasability_status(self,
-                                 version: str,
                                  nb_of_commits: int = 5,
                                  step: int = 4,
                                  timeout: int = 300,
                                  check_releasable: bool = True) -> bool:
         r"""Get Burgrx for latest releasability status (polls until all checks have completed.)
 
-        :param version: full version to be checked for releasability.
         :param nb_of_commits: number of latest commits on the branch to get the status from.
         :param step: step in seconds between polls. (For testing, otherwise use default value)
         :param timeout: timeout in seconds for attempting to get status. (For testing, otherwise use default value)
@@ -118,11 +112,10 @@ class Burgr:
             "nbOfCommits": nb_of_commits,
             "startAtCommit": 0
         }
-
         try:
             releasability = polling.poll(
                 lambda: self.get_latest_releasability_stage(requests.get(url, params=url_params, auth=self.auth_header),
-                                                            version,
+                                                            self.release_request.version,
                                                             check_releasable),
                 step=step,
                 timeout=timeout)

--- a/main/release/utils/github.py
+++ b/main/release/utils/github.py
@@ -3,56 +3,51 @@ import os
 import re
 import requests
 
+from release.steps.ReleaseRequest import ReleaseRequest
+
+
+class GitHubException(Exception):
+    pass
+
 
 class GitHub:
-    github_api_url: str
-    github_token: str
-    github_event: {}
+    token: str
+    event: {}
 
-    def __init__(self, github_api_url, github_token, github_event_path):
-        with open(github_event_path) as file:
-            self.github_event = json.load(file)
-        self.github_token = github_token
-        self.github_api_url = github_api_url
+    def __init__(self):
+        self.token = os.environ.get('GITHUB_TOKEN')
+        if os.environ.get('GITHUB_EVENT_NAME') != 'release':
+            raise GitHubException('The action was not triggered on release event')
+        with open(os.environ.get('GITHUB_EVENT_PATH')) as file:
+            self.event = json.load(file)
 
-    def release_info(self, version=None) -> {}:
-        if version is None:
-            return self.github_event["release"]
-        elif self.github_event["release"].get('tag_name') == version:
-            return self.github_event["release"]
-        else:
-            return None
+    def get_release_request(self) -> ReleaseRequest:
+        repo = self._get_repository()["full_name"]
+        organisation, project = repo.split("/")
+        version = self._get_release()['tag_name']
+        # tag shall be like X.X.X.BUILD_NUMBER or X.X.X-MX.BUILD_NUMBER or X.X.X+BUILD_NUMBER (SEMVER)
+        version_pattern = re.compile(r'^\d+\.\d+\.\d+(?:-M\d+)?[.+](\d+)$')
+        version_match = version_pattern.match(version)
+        if version_match is None:
+            raise GitHubException('The tag must follow this pattern: X.X.X.BUILD_NUMBER or X.X.X-MX.BUILD_NUMBER or X.X.X+BUILD_NUMBER')
+        return ReleaseRequest(organisation, project,
+                              version, version_match.groups()[0],
+                              self._get_release()['target_commitish'], os.environ.get('GITHUB_SHA'))
 
-    def repository_full_name(self) -> str:
-        return self.github_event["repository"]["full_name"]
+    def revoke_release(self) -> None:
+        tag_name = self._get_release()["tag_name"]
+        headers = {'Authorization': f'token {self.token}'}
+        payload = {'draft': True, 'tag_name': tag_name}
+        requests.patch(self._get_release()['url'], json=payload, headers=headers)
+        # Delete tag
+        requests.delete(self._get_repository().get("git_refs_url").replace("{/sha}", f'/tags/{tag_name}'), headers=headers)
 
-    def repository_info(self):
-        return self.github_event["repository"]
+    @staticmethod
+    def is_publish_to_binaries():
+        return os.environ.get('INPUT_PUBLISH_TO_BINARIES', 'false').lower() == "true"
 
-    def current_branch(self):
-        possible_branch_name = self.release_info()['target_commitish']
-        if re.compile("^([a-f0-9]{40})$").match(possible_branch_name):
-            return 'master'
-        return possible_branch_name
+    def _get_release(self) -> {}:
+        return self.event["release"]
 
-    def get_sha(self):
-        return os.environ.get('GITHUB_SHA')
-
-    def get_repo(self):
-        return os.environ.get('GITHUB_REPOSITORY')
-
-    def get_ref(self):
-        return os.environ.get('GITHUB_REF')
-
-    def revoke_release(self):
-        if not self.release_info().get('id'):
-            return None
-        version = self.release_info()["tag_name"]
-        url = self.repository_info().get("releases_url").replace("{/id}", str(self.release_info().get('id')))
-        headers = {'Authorization': f"token {self.github_token}"}
-        payload = {'draft': True, 'tag_name': version}
-        r = requests.patch(url, json=payload, headers=headers)
-        # delete tag
-        url = f"{self.github_api_url}/repos/{self.repository_full_name()}/git/refs/tags/{version}"
-        requests.delete(url, headers=headers)
-        return r.json()
+    def _get_repository(self) -> {}:
+        return self.event["repository"]

--- a/main/release/utils/github.py
+++ b/main/release/utils/github.py
@@ -30,9 +30,12 @@ class GitHub:
         version_match = version_pattern.match(version)
         if version_match is None:
             raise GitHubException('The tag must follow this pattern: X.X.X.BUILD_NUMBER or X.X.X-MX.BUILD_NUMBER or X.X.X+BUILD_NUMBER')
+        branch_name = self._get_release()['target_commitish']
+        if re.compile("^([a-f0-9]{40})$").match(branch_name):
+            branch_name = 'master'
         return ReleaseRequest(organisation, project,
                               version, version_match.groups()[0],
-                              self._get_release()['target_commitish'], os.environ.get('GITHUB_SHA'))
+                              branch_name, os.environ.get('GITHUB_SHA'))
 
     def revoke_release(self) -> None:
         tag_name = self._get_release()["tag_name"]

--- a/main/release/vars.py
+++ b/main/release/vars.py
@@ -1,15 +1,9 @@
 import os
 from slack_sdk import WebClient
 
-githup_api_url = "https://api.github.com"
-github_token = os.environ.get('GITHUB_TOKEN', 'no github token in env')
-github_event_path = os.environ.get('GITHUB_EVENT_PATH')
-
 burgrx_url = 'https://burgrx.sonarsource.com'
 burgrx_user = os.environ.get('BURGRX_USER', 'no burgrx user in env')
 burgrx_password = os.environ.get('BURGRX_PASSWORD', 'no burgrx password in env')
-
-publish_to_binaries: bool = os.environ.get('INPUT_PUBLISH_TO_BINARIES', 'false').lower() == "true"
 
 artifactory_apikey = os.environ.get('ARTIFACTORY_API_KEY', 'no api key in env')
 

--- a/main/tests/burgr_test.py
+++ b/main/tests/burgr_test.py
@@ -7,7 +7,7 @@ from release.utils.burgr import Burgr
 
 @fixture
 def release_request():
-    return ReleaseRequest('org', 'project', 'buildnumber', 'branch', 'sha')
+    return ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
 
 
 class BurgrResponse:
@@ -42,7 +42,7 @@ def test_notify(release_request):
 
 def test_releasability_checks(release_request):
     with patch('release.utils.burgr.requests.post', return_value=BurgrResponse(200)) as request:
-        Burgr('url', 'user', 'password', release_request).start_releasability_checks('version')
+        Burgr('url', 'user', 'password', release_request).start_releasability_checks()
         request.assert_called_once_with(
             'url/api/project/SonarSource/project/releasability/start/version',
             auth=ANY

--- a/main/tests/github_test.py
+++ b/main/tests/github_test.py
@@ -1,31 +1,88 @@
 import os
 from unittest.mock import patch, mock_open
+import pytest
 
-from release.utils.github import GitHub
+from release.utils.github import GitHub, GitHubException
 
 
-@patch.dict(os.environ, {'GITHUB_SHA': '42'}, clear=True)
-@patch('release.utils.github.json.load', return_value={})
-def test_get_sha(mock_json_load):
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'push'}, clear=True)
+def test_must_fail_on_non_release_event():
+    with pytest.raises(GitHubException, match='The action was not triggered on release event'):
+        GitHub()
+
+
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
+@patch('release.utils.github.json.load',
+       return_value={
+           'repository': {'full_name': 'org/project'},
+           'release': {'tag_name': 'bad version'},
+       })
+def test_must_fail_if_tag_not_following_version_pattern(mock_release_event):
     with patch('release.utils.github.open', mock_open()) as open_mock:
-        assert GitHub('github_api_url', 'github_token', 'github_event_path').get_sha() == '42'
+        with pytest.raises(GitHubException, match='The tag must follow this pattern: '):
+            GitHub().get_release_request()
         open_mock.assert_called_once()
-        mock_json_load.assert_called_once()
+        mock_release_event.assert_called_once()
 
 
-@patch.dict(os.environ, {'GITHUB_REPOSITORY': 'github_repo'}, clear=True)
-@patch('release.utils.github.json.load', return_value={})
-def test_get_repo(mock_json_load):
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release', 'GITHUB_SHA': 'sha'}, clear=True)
+@patch('release.utils.github.json.load',
+       return_value={
+           'repository': {
+               'full_name': 'org/project'
+           },
+           'release': {
+               'tag_name': '1.0.0.42',
+               'target_commitish': 'branch'
+           },
+       })
+def test_must_succeed_with_correct_tag(mock_release_event):
     with patch('release.utils.github.open', mock_open()) as open_mock:
-        assert GitHub('github_api_url', 'github_token', 'github_event_path').get_repo() == 'github_repo'
+
+        release_request = GitHub().get_release_request()
+        assert release_request.org == 'org'
+        assert release_request.project == 'project'
+        assert release_request.version == '1.0.0.42'
+        assert release_request.buildnumber == '42'
+        assert release_request.branch == 'branch'
+        assert release_request.sha == 'sha'
         open_mock.assert_called_once()
-        mock_json_load.assert_called_once()
+        mock_release_event.assert_called_once()
 
 
-@patch.dict(os.environ, {'GITHUB_REF': 'github_ref'}, clear=True)
-@patch('release.utils.github.json.load', return_value={})
-def test_get_ref(mock_json_load):
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release', 'GITHUB_SHA': 'sha', 'GITHUB_TOKEN': 'token'}, clear=True)
+@patch('requests.delete')
+@patch('requests.patch')
+@patch('release.utils.github.json.load',
+       return_value={
+           'repository': {
+               'git_refs_url': 'git_refs_url{/sha}'
+           },
+           'release': {
+               'tag_name': '1.0.0.42',
+               'url': 'release_url'
+           },
+       })
+def test_revoke_release(mock_release_event, mock_update_release, mock_delete_tag):
     with patch('release.utils.github.open', mock_open()) as open_mock:
-        assert GitHub('github_api_url', 'github_token', 'github_event_path').get_ref() == 'github_ref'
+        GitHub().revoke_release()
         open_mock.assert_called_once()
-        mock_json_load.assert_called_once()
+        mock_release_event.assert_called_once()
+        mock_update_release.assert_called_once_with(
+            'release_url',
+            json={'draft': True, 'tag_name': '1.0.0.42'},
+            headers={'Authorization': f'token token'}
+        )
+        mock_delete_tag.assert_called_once_with(
+            'git_refs_url/tags/1.0.0.42',
+            headers={'Authorization': f'token token'}
+        )
+
+
+@patch.dict(os.environ, {'INPUT_PUBLISH_TO_BINARIES': 'true'}, clear=True)
+def test_do_publish_to_binaries():
+    assert GitHub.is_publish_to_binaries()
+
+
+def test_do_not_publish_to_binaries():
+    assert not GitHub.is_publish_to_binaries()

--- a/main/tests/github_test.py
+++ b/main/tests/github_test.py
@@ -50,6 +50,31 @@ def test_must_succeed_with_correct_tag(mock_release_event):
         mock_release_event.assert_called_once()
 
 
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release', 'GITHUB_SHA': 'sha'}, clear=True)
+@patch('release.utils.github.json.load',
+       return_value={
+           'repository': {
+               'full_name': 'org/project'
+           },
+           'release': {
+               'tag_name': '1.0.0.42',
+               'target_commitish': 'c747bee7bf5cfc8c0ad5fbc126d516c0a1aa42ef'
+           },
+       })
+def test_must_succeed_with_target_commitish_containing_a_commit(mock_release_event):
+    with patch('release.utils.github.open', mock_open()) as open_mock:
+
+        release_request = GitHub().get_release_request()
+        assert release_request.org == 'org'
+        assert release_request.project == 'project'
+        assert release_request.version == '1.0.0.42'
+        assert release_request.buildnumber == '42'
+        assert release_request.branch == 'master'
+        assert release_request.sha == 'sha'
+        open_mock.assert_called_once()
+        mock_release_event.assert_called_once()
+
+
 @patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release', 'GITHUB_SHA': 'sha', 'GITHUB_TOKEN': 'token'}, clear=True)
 @patch('requests.delete')
 @patch('requests.patch')

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -1,38 +1,100 @@
-from unittest.mock import patch, mock_open
+import os
+from unittest.mock import patch, mock_open, ANY, call, Mock, MagicMock
 
-from release.main import main
+import pytest
+
+from release.main import main, set_output, abort_release
+from release.steps.ReleaseRequest import ReleaseRequest
 from release.utils.artifactory import Artifactory
 from release.utils.burgr import Burgr
 from release.utils.github import GitHub
 
 
-@patch('release.utils.github.json.load', return_value={})
-@patch.object(GitHub, 'get_repo', return_value='org/project')
-@patch.object(GitHub, 'get_ref', return_value='refs/tags/1.0.0.42')
-@patch.object(GitHub, 'release_info')
-@patch.object(GitHub, 'current_branch', return_value='branch')
+def test_set_output(capfd):
+    set_output('function', 'output')
+    out, err = capfd.readouterr()
+    assert out == "::set-output name=function::function output\n"
+    assert not err
+
+
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
+@patch('release.utils.github.json.load')
+@patch.object(Burgr, 'start_releasability_checks', side_effect=Exception('exception'))
+@patch('release.main.notify_slack')
+@patch.object(GitHub, 'revoke_release')
+def test_releasability_failure(github_revoke_release, notify_slack,
+                               burgr_start_releasability_checks,
+                               github_event):
+    with patch('release.utils.github.open', mock_open()) as open_mock:
+        release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
+        with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
+            with pytest.raises(Exception, match='exception'):
+                main()
+                open_mock.assert_called_once()
+                github_event.assert_called_once()
+                github_release_request.assert_called_once()
+                burgr_start_releasability_checks.assert_called_once()
+                notify_slack.assert_called_once_with('"Released project:version failed')
+                github_revoke_release.assert_called_once()
+
+
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
+@patch('release.utils.github.json.load')
+@patch.object(Burgr, 'start_releasability_checks')
+@patch.object(Burgr, 'get_releasability_status')
+@patch.object(Artifactory, 'receive_build_info')
+@patch.object(Artifactory, 'promote', side_effect=Exception('exception'))
+@patch('release.main.notify_slack')
+@patch('release.main.abort_release')
+def test_promotion_failure(abort_release, notify_slack,
+                           artifactory_promote, artifactory_receive_build_info,
+                           burgr_start_releasability_checks, burgr_get_releasability_status,
+                           github_event):
+    with patch('release.utils.github.open', mock_open()) as open_mock:
+        release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
+        with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
+            with pytest.raises(Exception, match='exception'):
+                main()
+                open_mock.assert_called_once()
+                github_event.assert_called_once()
+                github_release_request.assert_called_once()
+                burgr_start_releasability_checks.assert_called_once()
+                burgr_get_releasability_status.assert_called_once()
+                artifactory_receive_build_info.assert_called_once_with(release_request)
+                artifactory_promote.assert_called_once_with(release_request, ANY)
+                notify_slack.assert_called_once_with('"Released project:version failed')
+                abort_release(ANY, ANY, ANY, release_request)
+
+
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
+@patch('release.utils.github.json.load')
 @patch.object(Burgr, 'start_releasability_checks')
 @patch.object(Burgr, 'get_releasability_status')
 @patch.object(Artifactory, 'receive_build_info')
 @patch.object(Artifactory, 'promote')
+@patch.object(GitHub, 'is_publish_to_binaries', return_value=True)
 @patch.object(Burgr, 'notify')
 @patch('release.main.notify_slack')
-def test_main(notify_slack,
-              burgr_notify,
-              artifactory_promote, artifactory_receive_build_info,
-              burgr_start_releasability_checks, burgr_get_releasability_status,
-              github_current_branch, github_release_info, github_get_ref, github_get_repo, test_json_load):
+@patch('release.main.set_output')
+def test_main_happy_path(set_output, notify_slack,
+                         burgr_notify,
+                         github_is_publish_to_binaries,
+                         artifactory_promote, artifactory_receive_build_info,
+                         burgr_start_releasability_checks, burgr_get_releasability_status,
+                         github_event):
     with patch('release.utils.github.open', mock_open()) as open_mock:
-        main()
-        open_mock.assert_called_once()
-        test_json_load.assert_called_once()
-        github_get_repo.assert_called_once()
-        github_get_ref.assert_called_once()
-        github_release_info.assert_called_once_with('1.0.0.42')
-        github_current_branch.assert_called_once()
-        burgr_start_releasability_checks.assert_called_once_with('1.0.0.42')
-        burgr_get_releasability_status.assert_called_once_with('1.0.0.42')
-        artifactory_receive_build_info.assert_called_once()
-        artifactory_promote.assert_called_once()
-        burgr_notify.assert_called_once_with('passed')
-        notify_slack.assert_called_once_with('Successfully released org/project:1.0.0.42')
+        release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
+        with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
+            main()
+            open_mock.assert_called_once()
+            github_event.assert_called_once()
+            github_release_request.assert_called_once()
+            burgr_start_releasability_checks.assert_called_once()
+            burgr_get_releasability_status.assert_called_once()
+            artifactory_receive_build_info.assert_called_once_with(release_request)
+            artifactory_promote.assert_called_once_with(release_request, ANY)
+            github_is_publish_to_binaries.assert_called_once()
+            burgr_notify.assert_called_once_with('passed')
+            notify_slack.assert_called_once_with('Successfully released project:version')
+            assert set_output.call_count == 3
+            set_output.assert_has_calls([call('releasability', 'done'), call('promote', 'done'), call('publish_to_binaries', 'done')])


### PR DESCRIPTION
I totally reviewed the GitHub class code:
* This handles everything about the release data (as this is the entry point of the process). The class creates the ReleaseRequest which is used by any other intergations (Artifactory, BURGR, ...)
* I used as much as possible the release event to extract the data (this is the concept of GitHub workflows)
* I cleaned up the main class to make it more maintainable and act as an orchestrator

 :white_check_mark: Tested: https://github.com/SonarSource/sonar-dummy/actions/runs/2635908409
 :white_check_mark: Tested: https://github.com/SonarSource/sonar-dummy/actions/runs/2655849784