### PR TITLE
BUILD-2509 dry run option for gh-action_release

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -27,15 +27,3 @@ jobs:
             dry_run: true
             publish_to_binaries: true
             slack_channel: build
-
-  mavenCentral:
-    name: "Maven Central (it-tests)"
-    runs-on: ubuntu-latest
-    needs: release
-    steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 #v3.5.0 (Necessary to access local action)
-      - uses: ./maven-central-sync
-        with:
-          vault-addr: vault.addr
-          artifactory-role-suffix: test
-          dry-run: true

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -11,8 +11,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  build:
-    name: "it-tests"
+  release:
+    name: "Release (it-tests)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 #v3.5.0 (Necessary to access local action)
@@ -25,5 +25,17 @@ jobs:
           SLACK_API_TOKEN: "slack-token-test"
         with:
             dry_run: true
-            publish_to_binaries: false
+            publish_to_binaries: true
             slack_channel: build
+
+  mavenCentral:
+    name: "Maven Central (it-tests)"
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 #v3.5.0 (Necessary to access local action)
+      - uses: ./maven-central-sync
+        with:
+          vault-addr: vault.addr
+          artifactory-role-suffix: test
+          dry-run: true

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -1,0 +1,29 @@
+# This workflow verifies that for the given sets of inputs/outputs the gh-action_release defined in the current branch (PR)
+# still works as expected.
+#
+# It checks for the current branch, and allows checking of new input/output parameters at the PR time  (Fail fast principles)
+# without having to release the action first and then use it in a side project.
+name: gh-action_release Integration Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: "it-tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4 # Necessary to access local action
+      - uses: ./main
+        env:
+          BURGRX_USER: "bob user"
+          BURGRX_PASSWORD: "*******"
+          ARTIFACTORY_ACCESS_TOKEN: "42"
+          BINARIES_AWS_DEPLOY: "s3://empty"
+          SLACK_API_TOKEN: "slack-token-test"
+        with:
+            dry_run: true
+            publish_to_binaries: false
+            slack_channel: build

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: "it-tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4 # Necessary to access local action
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 #v3.5.0 (Necessary to access local action)
       - uses: ./main
         env:
           BURGRX_USER: "bob user"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,7 @@ jobs:
             development/aws/sts/downloads security_token | binaries_aws_security_token;
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@b50e74b676f07064df898257e1b98cfce584a3b7
+        uses: SonarSource/gh-action_release/main@feature/svermeille/BUILD-2509-Dry-run-option-for-gh-action_release
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
@@ -99,8 +99,8 @@ jobs:
   mavenCentral:
     name: Maven Central
     needs: release
-    if: ${{ inputs.mavenCentralSync }}
-    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@v5
+    if: ${{ inputs.mavenCentralSync && inputs.dryRun != true }}
+    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@feature/svermeille/BUILD-2509-Dry-run-option-for-gh-action_release
     with:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,7 @@ jobs:
             development/aws/sts/downloads security_token | binaries_aws_security_token;
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@v5
+        uses: SonarSource/gh-action_release/main@b50e74b676f07064df898257e1b98cfce584a3b7
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,7 @@ jobs:
             development/aws/sts/downloads security_token | binaries_aws_security_token;
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@feature/svermeille/BUILD-2509-Dry-run-option-for-gh-action_release
+        uses: SonarSource/gh-action_release/main@v5
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
@@ -100,7 +100,7 @@ jobs:
     name: Maven Central
     needs: release
     if: ${{ inputs.mavenCentralSync && inputs.dryRun != true }}
-    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@feature/svermeille/BUILD-2509-Dry-run-option-for-gh-action_release
+    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@v5
     with:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,11 @@ name: Release
 on:
   workflow_call:
     inputs:
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
       publishToBinaries:
         type: boolean
         description: Flag to enable the publication to binaries
@@ -70,6 +75,7 @@ jobs:
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
+          dry_run: ${{ inputs.dryRun }}
         env:
           PYTHONUNBUFFERED: 1
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -23,7 +23,7 @@ jobs:
       id-token: write  # to authenticate via OIDC
       contents: read  # to revert a github release
     timeout-minutes: 30
-    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    if: github.event_name == 'release' && github.event.action == 'published'
     outputs:
       maven-central: ${{ steps.maven-central-sync.outcome }}
     steps:
@@ -60,7 +60,7 @@ jobs:
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@v5
+        uses: SonarSource/gh-action_release/maven-central-sync@feature/svermeille/BUILD-2509-Dry-run-option-for-gh-action_release # svermeille feature branch
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -23,7 +23,7 @@ jobs:
       id-token: write  # to authenticate via OIDC
       contents: read  # to revert a github release
     timeout-minutes: 30
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
     outputs:
       maven-central: ${{ steps.maven-central-sync.outcome }}
     steps:
@@ -60,7 +60,7 @@ jobs:
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@feature/svermeille/BUILD-2509-Dry-run-option-for-gh-action_release # svermeille feature branch
+        uses: SonarSource/gh-action_release/maven-central-sync@v5
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
       - id: check-github-actions
         files: .*/action.ya?ml
       - id: check-github-workflows
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: 5341f388c2a962d3bc66e075f00b80ab45b15f24 # v0.1.20
+    hooks:
+      - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@ repos:
       - id: check-hooks-apply
       - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3298ddab3c13dd77d6ce1fc0baf97691430d84b0  # frozen: v4.3.0
+    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9  # frozen: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-added-large-files
       - id: check-executables-have-shebangs
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 9ff55b0adf11b603e0e2b4e1d639255278f4316f  # frozen: 0.18.3
+    rev: 20447075e31543a8b125f2df18d75f3b5e7d4d2e  # frozen: 0.22.0
     hooks:
       - id: check-github-actions
         files: .*/action.ya?ml

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Available options:
 - mavenCentralSync (default: false): enable synchronization to Maven Central, **for OSS projects only**
 - slackChannel (default: build): notification Slack channel
 - artifactoryRoleSuffix (default: promoter): Artifactory promoter suffix
+- dryRun (default: false): perform a dry run execution
+
+## Dry Run
+For testing purpose you may want to use this gh-action without really releasing.
+There comes the dry run.
+
+What the dry run will do and not do:
+* Will not communicate with burger
+* Will not promote any artifacts in repox
+* Will not push binaries
+* Will not publish to slack
+
+Instead, it will actually print the sequence of operations that would have 
+been performed based on the provided inputs defined in `with:` section.
 
 ## Versioning
 

--- a/main/Pipfile
+++ b/main/Pipfile
@@ -12,6 +12,10 @@ requests = "*"
 polling = "*"
 slack_sdk = "*"
 boto3 = "*"
+dryrun = "*"
+dryable = "*"
+parameterized = "*"
+parametrized = "*"
 
 [requires]
 python_version = "3.10"

--- a/main/Pipfile.lock
+++ b/main/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ab70b94b17cdad225dadbea6b46cf18543953f6a065a74594b9e879cb207e9c0"
+            "sha256": "78e143a685bbc7c9fd34469463544dcba78ad2d6d8f1eb13ceae0a1862a09f42"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,43 +18,131 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:626bbec91ca2423e427636db207a03c854b52d22715c9b34a953ee8260817f6f",
-                "sha256:7e0a5c86059866d7f9e27d6574da9bfb4f8a03c4caf055724145f3cd44785b81"
+                "sha256:19762b6a1adbe1963e26b8280211ca148017c970a2e1386312a9fc8a0a17dbd5",
+                "sha256:367a73c1ff04517849d8c4177fd775da2e258a3912ff6a497be258c30f509046"
             ],
             "index": "pypi",
-            "version": "==1.24.27"
+            "version": "==1.26.97"
         },
         "botocore": {
             "hashes": [
-                "sha256:524da451350c41e3136353183e7424c95952124163ea8ec03f57f29597bbcb4b",
-                "sha256:583b85f8a799fb89d1a762db041163b5848b08e79cee06b609bcaaeb69ea1fa6"
+                "sha256:0df677eb2bef3ba18ac69e007633559b4426df310eee99df9882437b5faf498a",
+                "sha256:176740221714c0f031c2cd773879df096dbc0f977c63b3e2ed6a956205f02e82"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.27"
+            "version": "==1.29.97"
         },
         "certifi": {
             "hashes": [
-                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
-                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
-            "markers": "python_full_version >= '3.6.0'",
-            "version": "==2022.6.15"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.12.7"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
-                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+                "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
+                "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
+                "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
+                "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
+                "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
+                "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
+                "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
+                "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
+                "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0",
+                "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448",
+                "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
+                "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
+                "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
+                "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
+                "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
+                "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
+                "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59",
+                "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23",
+                "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5",
+                "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
+                "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
+                "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
+                "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
+                "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
+                "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
+                "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
+                "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974",
+                "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
+                "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
+                "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
+                "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
+                "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8",
+                "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
+                "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
+                "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
+                "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
+                "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
+                "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
+                "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
+                "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
+                "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
+                "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
+                "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
+                "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b",
+                "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
+                "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
+                "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
+                "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1",
+                "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
+                "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
+                "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
+                "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
+                "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
+                "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
+                "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
+                "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
+                "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909",
+                "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
+                "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
+                "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
+                "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755",
+                "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
+                "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
+                "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
+                "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
+                "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
+                "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
+                "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
+                "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
+                "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
+                "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
+                "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
+                "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
+                "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
+                "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
             ],
-            "markers": "python_full_version >= '3.6.0'",
-            "version": "==2.1.0"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.1.0"
+        },
+        "dryable": {
+            "hashes": [
+                "sha256:193c89bf76785046d4b473a00216c76c5d1cbd06ea858621419fcb89889edd4c"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0"
+        },
+        "dryrun": {
+            "hashes": [
+                "sha256:761299a4ae57d127599719986e6830e83fa62152b62308e801c0c573562b2bb6",
+                "sha256:d1e1aee02181b39c6f88f94a0122b965f19d7a31291243a61b007580c8a1ead6"
+            ],
+            "index": "pypi",
+            "version": "==1.0.1"
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.3"
+            "version": "==3.4"
         },
         "jmespath": {
             "hashes": [
@@ -63,6 +151,22 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.0.1"
+        },
+        "parameterized": {
+            "hashes": [
+                "sha256:41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c",
+                "sha256:9cbb0b69a03e8695d68b3399a8a5825200976536fe1cb79db60ed6a4c8c9efe9"
+            ],
+            "index": "pypi",
+            "version": "==0.8.1"
+        },
+        "parametrized": {
+            "hashes": [
+                "sha256:ad55c4d803715bd921869701757bd3604dfa1deacdee53e835c0a4840ddb102d",
+                "sha256:f2d42384fee14ecceb09156a2219415c9a92af998b183092bc7f27ba3fd3c7f5"
+            ],
+            "index": "pypi",
+            "version": "==0.1"
         },
         "polling": {
             "hashes": [
@@ -81,11 +185,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
-                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+                "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+                "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"
             ],
             "index": "pypi",
-            "version": "==2.28.1"
+            "version": "==2.28.2"
         },
         "s3transfer": {
             "hashes": [
@@ -105,94 +209,113 @@
         },
         "slack-sdk": {
             "hashes": [
-                "sha256:60302e32d48db6b4ea5453d92f23ecf3f7b843f799f61eaf271315264d7cb281",
-                "sha256:70d5a55a5d52ba7128d5347ed995425e1f83e729667ab296035bcf6c1b13a049"
+                "sha256:224fcb4fef9575226e76555d9a0acdbd93d7596a416bc3ae7b443b3b64e9f0e3",
+                "sha256:f61db1f6e49dd2ee84e82ddb5d1c5db7a5987b8be9ba975dc00799334c84f8cd"
             ],
             "index": "pypi",
-            "version": "==3.17.2"
+            "version": "==3.20.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
-                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+                "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
+                "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.10"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.15"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==22.2.0"
         },
         "coverage": {
             "extras": [
                 "toml"
             ],
             "hashes": [
-                "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749",
-                "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982",
-                "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3",
-                "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9",
-                "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428",
-                "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e",
-                "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c",
-                "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9",
-                "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264",
-                "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605",
-                "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397",
-                "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d",
-                "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c",
-                "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815",
-                "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068",
-                "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b",
-                "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4",
-                "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4",
-                "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3",
-                "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84",
-                "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83",
-                "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4",
-                "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8",
-                "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb",
-                "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d",
-                "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df",
-                "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6",
-                "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b",
-                "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72",
-                "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13",
-                "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df",
-                "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc",
-                "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6",
-                "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28",
-                "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b",
-                "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4",
-                "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad",
-                "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46",
-                "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3",
-                "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9",
-                "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"
+                "sha256:006ed5582e9cbc8115d2e22d6d2144a0725db542f654d9d4fda86793832f873d",
+                "sha256:046936ab032a2810dcaafd39cc4ef6dd295df1a7cbead08fe996d4765fca9fe4",
+                "sha256:0484d9dd1e6f481b24070c87561c8d7151bdd8b044c93ac99faafd01f695c78e",
+                "sha256:0ce383d5f56d0729d2dd40e53fe3afeb8f2237244b0975e1427bfb2cf0d32bab",
+                "sha256:186e0fc9cf497365036d51d4d2ab76113fb74f729bd25da0975daab2e107fd90",
+                "sha256:2199988e0bc8325d941b209f4fd1c6fa007024b1442c5576f1a32ca2e48941e6",
+                "sha256:299bc75cb2a41e6741b5e470b8c9fb78d931edbd0cd009c58e5c84de57c06731",
+                "sha256:3668291b50b69a0c1ef9f462c7df2c235da3c4073f49543b01e7eb1dee7dd540",
+                "sha256:36dd42da34fe94ed98c39887b86db9d06777b1c8f860520e21126a75507024f2",
+                "sha256:38004671848b5745bb05d4d621526fca30cee164db42a1f185615f39dc997292",
+                "sha256:387fb46cb8e53ba7304d80aadca5dca84a2fbf6fe3faf6951d8cf2d46485d1e5",
+                "sha256:3eb55b7b26389dd4f8ae911ba9bc8c027411163839dea4c8b8be54c4ee9ae10b",
+                "sha256:420f94a35e3e00a2b43ad5740f935358e24478354ce41c99407cddd283be00d2",
+                "sha256:4ac0f522c3b6109c4b764ffec71bf04ebc0523e926ca7cbe6c5ac88f84faced0",
+                "sha256:4c752d5264053a7cf2fe81c9e14f8a4fb261370a7bb344c2a011836a96fb3f57",
+                "sha256:4f01911c010122f49a3e9bdc730eccc66f9b72bd410a3a9d3cb8448bb50d65d3",
+                "sha256:4f68ee32d7c4164f1e2c8797535a6d0a3733355f5861e0f667e37df2d4b07140",
+                "sha256:4fa54fb483decc45f94011898727802309a109d89446a3c76387d016057d2c84",
+                "sha256:507e4720791977934bba016101579b8c500fb21c5fa3cd4cf256477331ddd988",
+                "sha256:53d0fd4c17175aded9c633e319360d41a1f3c6e352ba94edcb0fa5167e2bad67",
+                "sha256:55272f33da9a5d7cccd3774aeca7a01e500a614eaea2a77091e9be000ecd401d",
+                "sha256:5764e1f7471cb8f64b8cda0554f3d4c4085ae4b417bfeab236799863703e5de2",
+                "sha256:57b77b9099f172804e695a40ebaa374f79e4fb8b92f3e167f66facbf92e8e7f5",
+                "sha256:5afdad4cc4cc199fdf3e18088812edcf8f4c5a3c8e6cb69127513ad4cb7471a9",
+                "sha256:5cc0783844c84af2522e3a99b9b761a979a3ef10fb87fc4048d1ee174e18a7d8",
+                "sha256:5e1df45c23d4230e3d56d04414f9057eba501f78db60d4eeecfcb940501b08fd",
+                "sha256:6146910231ece63facfc5984234ad1b06a36cecc9fd0c028e59ac7c9b18c38c6",
+                "sha256:797aad79e7b6182cb49c08cc5d2f7aa7b2128133b0926060d0a8889ac43843be",
+                "sha256:7c20b731211261dc9739bbe080c579a1835b0c2d9b274e5fcd903c3a7821cf88",
+                "sha256:817295f06eacdc8623dc4df7d8b49cea65925030d4e1e2a7c7218380c0072c25",
+                "sha256:81f63e0fb74effd5be736cfe07d710307cc0a3ccb8f4741f7f053c057615a137",
+                "sha256:872d6ce1f5be73f05bea4df498c140b9e7ee5418bfa2cc8204e7f9b817caa968",
+                "sha256:8c99cb7c26a3039a8a4ee3ca1efdde471e61b4837108847fb7d5be7789ed8fd9",
+                "sha256:8dbe2647bf58d2c5a6c5bcc685f23b5f371909a5624e9f5cd51436d6a9f6c6ef",
+                "sha256:8efb48fa743d1c1a65ee8787b5b552681610f06c40a40b7ef94a5b517d885c54",
+                "sha256:92ebc1619650409da324d001b3a36f14f63644c7f0a588e331f3b0f67491f512",
+                "sha256:9d22e94e6dc86de981b1b684b342bec5e331401599ce652900ec59db52940005",
+                "sha256:ba279aae162b20444881fc3ed4e4f934c1cf8620f3dab3b531480cf602c76b7f",
+                "sha256:bc4803779f0e4b06a2361f666e76f5c2e3715e8e379889d02251ec911befd149",
+                "sha256:bfe7085783cda55e53510482fa7b5efc761fad1abe4d653b32710eb548ebdd2d",
+                "sha256:c448b5c9e3df5448a362208b8d4b9ed85305528313fca1b479f14f9fe0d873b8",
+                "sha256:c90e73bdecb7b0d1cea65a08cb41e9d672ac6d7995603d6465ed4914b98b9ad7",
+                "sha256:d2b96123a453a2d7f3995ddb9f28d01fd112319a7a4d5ca99796a7ff43f02af5",
+                "sha256:d52f0a114b6a58305b11a5cdecd42b2e7f1ec77eb20e2b33969d702feafdd016",
+                "sha256:d530191aa9c66ab4f190be8ac8cc7cfd8f4f3217da379606f3dd4e3d83feba69",
+                "sha256:d683d230b5774816e7d784d7ed8444f2a40e7a450e5720d58af593cb0b94a212",
+                "sha256:db45eec1dfccdadb179b0f9ca616872c6f700d23945ecc8f21bb105d74b1c5fc",
+                "sha256:db8c2c5ace167fd25ab5dd732714c51d4633f58bac21fb0ff63b0349f62755a8",
+                "sha256:e2926b8abedf750c2ecf5035c07515770944acf02e1c46ab08f6348d24c5f94d",
+                "sha256:e627dee428a176ffb13697a2c4318d3f60b2ccdde3acdc9b3f304206ec130ccd",
+                "sha256:efe1c0adad110bf0ad7fb59f833880e489a61e39d699d37249bdf42f80590169"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.4.1"
+            "version": "==7.2.2"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
+                "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.1"
         },
         "iniconfig": {
             "hashes": [
-                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
             ],
-            "version": "==1.1.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.0"
         },
         "pluggy": {
             "hashes": [
@@ -202,44 +325,28 @@
             "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
         },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.11.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
-        },
         "pytest": {
             "hashes": [
-                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
-                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
+                "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e",
+                "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"
             ],
             "index": "pypi",
-            "version": "==7.1.2"
+            "version": "==7.2.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6",
-                "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"
+                "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b",
+                "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==4.0.0"
         },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         }
     }

--- a/main/action.yml
+++ b/main/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: "Channel to post notifications"
     required: false
   dry_run:
-    description: "Don't actually do anything, but still report what would be done (when true)."
+    description: "Don't actually do anything, report what would have been done."
     default: 'false'
     required: false
 outputs:

--- a/main/action.yml
+++ b/main/action.yml
@@ -9,6 +9,10 @@ inputs:
   slack_channel:
     description: "Channel to post notifications"
     required: false
+  dry_run:
+    description: "Don't actually do anything, but still report what would be done (when true)."
+    default: 'false'
+    required: false
 outputs:
   releasability:
     description: "Output to detect if releasability was successful"

--- a/main/release/exceptions/invalid_input_parameters_exception.py
+++ b/main/release/exceptions/invalid_input_parameters_exception.py
@@ -1,3 +1,3 @@
 class InvalidInputParametersException(Exception):
-    """Raised when the provided input environment variables are not correctly filled."""
+    """Raised when the provided input environment variables are invalid."""
     pass

--- a/main/release/exceptions/invalid_input_parameters_exception.py
+++ b/main/release/exceptions/invalid_input_parameters_exception.py
@@ -1,0 +1,3 @@
+class InvalidInputParametersException(Exception):
+    """Raised when the provided input environment variables are not correctly filled."""
+    pass

--- a/main/release/main.py
+++ b/main/release/main.py
@@ -11,13 +11,12 @@ from release.utils.burgr import Burgr
 from release.utils.dryrun import DryRunHelper
 from release.utils.github import GitHub
 from release.utils.release import revoke_release, publish_all_artifacts_to_binaries
-from release.vars import burgrx_url, burgrx_user, burgrx_password, slack_client, slack_channel, binaries_bucket_name, project_name
+from release.vars import burgrx_url, burgrx_user, burgrx_password, slack_client, slack_channel, binaries_bucket_name
 
 mandatory_env_variables = [
     "BURGRX_USER",
     "BURGRX_PASSWORD",
-    "ARTIFACTORY_ACCESS_TOKEN",
-    "BINARIES_AWS_DEPLOY"
+    "ARTIFACTORY_ACCESS_TOKEN"
 ]
 
 
@@ -47,7 +46,7 @@ def abort_release(github: GitHub, artifactory: Artifactory, binaries: Binaries, 
 def check_params():
     """A function that prevent further execution when input and output gh-action parameters are not valid"""
 
-    print(f"Checking {project_name} input/output parameters ...")
+    print("Checking gh-action_release input/output parameters ...")
 
     errors = []
     for mandatory_env in mandatory_env_variables:
@@ -57,14 +56,16 @@ def check_params():
     if os.environ.get('INPUT_SLACK_CHANNEL') is not None and os.environ.get('SLACK_API_TOKEN') is None:
         errors.append('env SLACK_API_TOKEN is empty but required as INPUT_SLACK_CHANNEL is defined')
 
+    if os.environ.get('INPUT_PUBLISH_TO_BINARIES', 'false').lower() == "true" and os.environ.get('BINARIES_AWS_DEPLOY') is None:
+        errors.append('env BINARIES_AWS_DEPLOY is empty but required as INPUT_PUBLISH_TO_BINARIES is true')
+
     if errors:
         new_line = "\n"
-        raise InvalidInputParametersException(f'The execution of {project_name} is aborted due to the following error(s):\n'
+        raise InvalidInputParametersException(f'The execution were aborted due to the following error(s):\n'
                                               f'{new_line.join(errors)}\n\n'
-                                              f'If you are using {project_name} and get this message,\n'
-                                              f' it probably means that the RE-team has to edit the vault policy of the current '
+                                              f'It is likely that the RE-team has to edit the vault policy of the current '
                                               f'repository to provide access to these secrets. \n\n'
-                                              f'Please get in touch with us so we can help you: #ask-release-engineering.'
+                                              f'Please contact #ask-release-engineering or release.engineers@sonarsource.com.'
                                               )
 
 

--- a/main/release/main.py
+++ b/main/release/main.py
@@ -1,35 +1,77 @@
-from release.utils.release import revoke_release, publish_all_artifacts_to_binaries
+import os
+
+from dryable import Dryable
+from slack_sdk.errors import SlackApiError
+
+from release.exceptions.invalid_input_parameters_exception import InvalidInputParametersException
 from release.steps.ReleaseRequest import ReleaseRequest
 from release.utils.artifactory import Artifactory
 from release.utils.binaries import Binaries
 from release.utils.burgr import Burgr
+from release.utils.dryrun import DryRunHelper
 from release.utils.github import GitHub
-from slack_sdk.errors import SlackApiError
-from release.vars import burgrx_url, burgrx_user, burgrx_password, artifactory_access_token, slack_client, slack_channel, binaries_bucket_name
+from release.utils.release import revoke_release, publish_all_artifacts_to_binaries
+from release.vars import burgrx_url, burgrx_user, burgrx_password, slack_client, slack_channel, binaries_bucket_name, project_name
+
+mandatory_env_variables = [
+    "BURGRX_USER",
+    "BURGRX_PASSWORD",
+    "ARTIFACTORY_ACCESS_TOKEN",
+    "BINARIES_AWS_DEPLOY"
+]
 
 
 def set_output(function, output):
     print(f"::set-output name={function}::{function} {output}")
 
 
+@Dryable(logging_msg='{function}({args}{kwargs})')
 def notify_slack(msg):
     if slack_channel is not None:
         try:
             return slack_client.chat_postMessage(
-                    channel=slack_channel,
-                    text=msg)
+                channel=slack_channel,
+                text=msg)
         except SlackApiError as e:
             print(f"Could not notify slack: {e.response['error']}")
 
 
+@Dryable(logging_msg='{function}()')
 def abort_release(github: GitHub, artifactory: Artifactory, binaries: Binaries, rr: ReleaseRequest):
-    print(f"::error Aborting release")
+    print("::error Aborting release")
     github.revoke_release()
     revoke_release(artifactory, binaries, rr)
     set_output("release", f"{rr.project}:{rr.buildnumber} revoked")
 
 
+def check_params():
+    """A function that prevent further execution when input and output gh-action parameters are not valid"""
+
+    print(f"Checking {project_name} input/output parameters ...")
+
+    errors = []
+    for mandatory_env in mandatory_env_variables:
+        if os.environ.get(mandatory_env) is None:
+            errors.append(f"env {mandatory_env} is empty")
+
+    if os.environ.get('INPUT_SLACK_CHANNEL') is not None and os.environ.get('SLACK_API_TOKEN') is None:
+        errors.append('env SLACK_API_TOKEN is empty but required as INPUT_SLACK_CHANNEL is defined')
+
+    if errors:
+        new_line = "\n"
+        raise InvalidInputParametersException(f'The execution of {project_name} is aborted due to the following error(s):\n'
+                                              f'{new_line.join(errors)}\n\n'
+                                              f'If you are using {project_name} and get this message,\n'
+                                              f' it probably means that the RE-team has to edit the vault policy of the current '
+                                              f'repository to provide access to these secrets. \n\n'
+                                              f'Please get in touch with us so we can help you: #ask-release-engineering.'
+                                              )
+
+
 def main():
+    check_params()
+    DryRunHelper.init()
+
     github = GitHub()
     release_request = github.get_release_request()
 
@@ -43,7 +85,7 @@ def main():
         github.revoke_release()
         raise e
 
-    artifactory = Artifactory(artifactory_access_token)
+    artifactory = Artifactory(os.environ.get('ARTIFACTORY_ACCESS_TOKEN'))
     buildinfo = artifactory.receive_build_info(release_request)
     binaries = None
     try:

--- a/main/release/main.py
+++ b/main/release/main.py
@@ -13,7 +13,7 @@ from release.utils.github import GitHub
 from release.utils.release import revoke_release, publish_all_artifacts_to_binaries
 from release.vars import burgrx_url, burgrx_user, burgrx_password, slack_client, slack_channel, binaries_bucket_name
 
-mandatory_env_variables = [
+MANDATORY_ENV_VARIABLES = [
     "BURGRX_USER",
     "BURGRX_PASSWORD",
     "ARTIFACTORY_ACCESS_TOKEN"
@@ -49,7 +49,7 @@ def check_params():
     print("Checking gh-action_release input/output parameters ...")
 
     errors = []
-    for mandatory_env in mandatory_env_variables:
+    for mandatory_env in MANDATORY_ENV_VARIABLES:
         if os.environ.get(mandatory_env) is None:
             errors.append(f"env {mandatory_env} is empty")
 

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -3,6 +3,7 @@ import urllib
 import requests
 import tempfile
 
+from dryable import Dryable
 from release.utils.buildinfo import BuildInfo
 
 
@@ -15,6 +16,7 @@ class Artifactory:
         self.access_token = access_token
         self.headers['Authorization'] = "Bearer "+access_token
 
+    @Dryable(logging_msg='{function}()')
     def receive_build_info(self, release_request):
         url = f"{self.url}/api/build/{release_request.project}/{release_request.buildnumber}"
         r = requests.get(url, headers=self.headers)
@@ -26,6 +28,7 @@ class Artifactory:
             print(r.content)
             raise Exception('unknown build')
 
+    @Dryable(logging_msg='{function}()')
     def promote(self, release_request, buildinfo, revoke=False):
         status = 'released'
         try:

--- a/main/release/utils/burgr.py
+++ b/main/release/utils/burgr.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 import json
 import polling
 import requests
+from dryable import Dryable
 from polling import TimeoutException
 from requests.auth import HTTPBasicAuth
 from requests.models import Response
@@ -52,6 +53,7 @@ class Burgr:
 
     # This will only work for a branch build, not a PR build
     # because a PR build notification needs `"pr_number": NUMBER` instead of `'branch': NAME`
+    @Dryable(logging_msg='{function}()')
     def notify(self, status):
         payload = {
             'repository': f"{self.release_request.org}/{self.release_request.project}",
@@ -74,6 +76,7 @@ class Burgr:
         if r.status_code != 201:
             print(f"burgr notification failed code:{r.status_code}")
 
+    @Dryable(logging_msg='{function}()')
     def start_releasability_checks(self):
         version = self.release_request.version
         print(f"Starting releasability check: {self.release_request.project}#{version}")
@@ -91,6 +94,7 @@ class Burgr:
             print(f"Releasability checks failed to start: {response} '{message}'")
             raise Exception(f"Releasability checks failed to start: '{message}'")
 
+    @Dryable(logging_msg='{function}()')
     def get_releasability_status(self,
                                  nb_of_commits: int = 5,
                                  step: int = 4,

--- a/main/release/utils/dryrun.py
+++ b/main/release/utils/dryrun.py
@@ -1,0 +1,37 @@
+import os
+import dryable
+import logging
+import sys
+
+
+class DryRunHelper:
+
+    disclaimer_message = """
+===
+DRY RUN
+gh-action_release has been invoked with input `dry_run=true`.
+It won't actually do anything having impacts, but will still report what would have been done.
+===
+    """
+
+    @staticmethod
+    def init():
+        dry_run: bool = DryRunHelper.is_dry_run_enabled()
+        if dry_run:
+            DryRunHelper.__print_disclaimer()
+            dryable.set(True)
+
+            console = logging.StreamHandler(sys.stdout)
+            console.setLevel(logging.INFO)
+            formatter = logging.Formatter('%(message)s (--dry-run)')  # custom format, avoid having the datetime,log level printed
+            console.setFormatter(formatter)
+            logging.getLogger("dryable").setLevel(logging.INFO)
+            logging.getLogger("dryable").addHandler(console)
+
+    @staticmethod
+    def is_dry_run_enabled():
+        return os.environ.get('INPUT_DRY_RUN', 'false').lower() == "true"
+
+    @classmethod
+    def __print_disclaimer(cls):
+        print(cls.disclaimer_message)

--- a/main/release/utils/github.py
+++ b/main/release/utils/github.py
@@ -2,9 +2,11 @@ import json
 import os
 import re
 import requests
+import logging
 
+from release.utils.dryrun import DryRunHelper
 from release.steps.ReleaseRequest import ReleaseRequest
-
+from dryable import Dryable
 
 class GitHubException(Exception):
     pass
@@ -13,30 +15,52 @@ class GitHubException(Exception):
 class GitHub:
     token: str
     event: {}
+    logger: logging.Logger
 
     def __init__(self):
         self.token = os.environ.get('GITHUB_TOKEN')
-        if os.environ.get('GITHUB_EVENT_NAME') != 'release':
-            raise GitHubException('The action was not triggered on release event')
-        with open(os.environ.get('GITHUB_EVENT_PATH')) as file:
-            self.event = json.load(file)
+        self.logger = logging.getLogger('gh-action')
+        if os.environ.get('GITHUB_EVENT_NAME') == 'release' or DryRunHelper.is_dry_run_enabled():
+            with open(os.environ.get('GITHUB_EVENT_PATH')) as file:
+                self.event = json.load(file)
+        else:
+            raise GitHubException('The action was neither triggered on release event, neither with dry_run=true')
 
     def get_release_request(self) -> ReleaseRequest:
+        if DryRunHelper.is_dry_run_enabled():
+            return self.__fake_release_request()
+        else:
+            repo = self._get_repository()["full_name"]
+            organisation, project = repo.split("/")
+
+
+            version = self._get_release()['tag_name']
+            # tag shall be like X.X.X.BUILD_NUMBER or X.X.X-MX.BUILD_NUMBER or X.X.X+BUILD_NUMBER (SEMVER)
+            version_pattern = re.compile(r'^\d+\.\d+\.\d+(?:-M\d+)?[.+](\d+)$')
+            version_match = version_pattern.match(version)
+            if version_match is None:
+                raise GitHubException('The tag must follow this pattern: X.X.X.BUILD_NUMBER or X.X.X-MX.BUILD_NUMBER or X.X.X+BUILD_NUMBER')
+            branch_name = self._get_release()['target_commitish']
+            if re.compile("^([a-f0-9]{40})$").match(branch_name):
+                branch_name = 'master'
+
+            return ReleaseRequest(organisation, project,
+                                  version, version_match.groups()[0],
+                                  branch_name, os.environ.get('GITHUB_SHA'))
+
+    def __fake_release_request(self) -> ReleaseRequest:
+        """Provide a dummy release request object, used when given dry_run is enabled"""
         repo = self._get_repository()["full_name"]
         organisation, project = repo.split("/")
-        version = self._get_release()['tag_name']
-        # tag shall be like X.X.X.BUILD_NUMBER or X.X.X-MX.BUILD_NUMBER or X.X.X+BUILD_NUMBER (SEMVER)
-        version_pattern = re.compile(r'^\d+\.\d+\.\d+(?:-M\d+)?[.+](\d+)$')
-        version_match = version_pattern.match(version)
-        if version_match is None:
-            raise GitHubException('The tag must follow this pattern: X.X.X.BUILD_NUMBER or X.X.X-MX.BUILD_NUMBER or X.X.X+BUILD_NUMBER')
-        branch_name = self._get_release()['target_commitish']
+        version = '?.?.?.????'
+        branch_name = 'master'
         if re.compile("^([a-f0-9]{40})$").match(branch_name):
             branch_name = 'master'
         return ReleaseRequest(organisation, project,
-                              version, version_match.groups()[0],
+                              version, "????",
                               branch_name, os.environ.get('GITHUB_SHA'))
 
+    @Dryable(logging_msg='{function}()')
     def revoke_release(self) -> None:
         tag_name = self._get_release()["tag_name"]
         headers = {'Authorization': f'token {self.token}'}

--- a/main/release/utils/github.py
+++ b/main/release/utils/github.py
@@ -49,7 +49,7 @@ class GitHub:
                                   branch_name, os.environ.get('GITHUB_SHA'))
 
     def __fake_release_request(self) -> ReleaseRequest:
-        """Provide a dummy release request object, used when given dry_run is enabled"""
+        """Provide a dummy release request object"""
         repo = self._get_repository()["full_name"]
         organisation, project = repo.split("/")
         version = '?.?.?.????'

--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -1,3 +1,4 @@
+from dryable import Dryable
 from release.utils.artifactory import Artifactory
 from release.steps import ReleaseRequest
 
@@ -26,6 +27,7 @@ def get_action(revoke):
         return "publishing"
 
 
+@Dryable(logging_msg='{function}({args})')
 def publish_all_artifacts_to_binaries(artifactory, binaries, release_request, buildinfo, revoke=False):
     print(f"{get_action(revoke)} artifacts for {release_request.project}#{release_request.buildnumber}")
     repo = buildinfo.get_property('buildInfo.env.ARTIFACTORY_DEPLOY_REPO').replace('qa', 'builds')

--- a/main/release/vars.py
+++ b/main/release/vars.py
@@ -2,13 +2,13 @@ import os
 from slack_sdk import WebClient
 
 burgrx_url = 'https://burgrx.sonarsource.com'
-burgrx_user = os.environ.get('BURGRX_USER', 'no burgrx user in env')
-burgrx_password = os.environ.get('BURGRX_PASSWORD', 'no burgrx password in env')
+burgrx_user = os.environ.get('BURGRX_USER')
+burgrx_password = os.environ.get('BURGRX_PASSWORD')
 
-artifactory_access_token = os.environ.get('ARTIFACTORY_ACCESS_TOKEN', 'no access token in env')
+binaries_bucket_name = os.environ.get('BINARIES_AWS_DEPLOY')
 
-binaries_bucket_name = os.environ.get('BINARIES_AWS_DEPLOY', 'no binaries bucket in the env')
-
-slack_token = os.environ.get('SLACK_API_TOKEN', 'no slack token in env')
+slack_token = os.environ.get('SLACK_API_TOKEN')
 slack_client = WebClient(slack_token)
 slack_channel = os.environ.get('INPUT_SLACK_CHANNEL') or None
+
+project_name = 'gh-action_release'

--- a/main/release/vars.py
+++ b/main/release/vars.py
@@ -10,5 +10,3 @@ binaries_bucket_name = os.environ.get('BINARIES_AWS_DEPLOY')
 slack_token = os.environ.get('SLACK_API_TOKEN')
 slack_client = WebClient(slack_token)
 slack_channel = os.environ.get('INPUT_SLACK_CHANNEL') or None
-
-project_name = 'gh-action_release'

--- a/main/tests/github_test.py
+++ b/main/tests/github_test.py
@@ -144,7 +144,6 @@ def test_get_release_request_should_return_fake_release_request_given_dry_run_is
         release_request = github.get_release_request()
 
         fake_release_request = github._GitHub__fake_release_request()
-        print(fake_release_request)
         assert release_request.org == fake_release_request.org
         assert release_request.project == fake_release_request.project
         assert release_request.version == fake_release_request.version
@@ -173,7 +172,6 @@ def test_get_release_request_should_not_return_fake_release_request_given_dry_ru
         release_request = github.get_release_request()
 
         fake_release_request = github._GitHub__fake_release_request()
-        print(fake_release_request)
         assert release_request.version != fake_release_request.version
         assert release_request.buildnumber != fake_release_request.buildnumber
         assert release_request.branch != fake_release_request.branch

--- a/main/tests/github_test.py
+++ b/main/tests/github_test.py
@@ -6,8 +6,20 @@ from release.utils.github import GitHub, GitHubException
 
 
 @patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'push'}, clear=True)
-def test_must_fail_on_non_release_event():
-    with pytest.raises(GitHubException, match='The action was not triggered on release event'):
+def test_must_fail_on_non_release_event_given_dry_run_not_true():
+    with pytest.raises(GitHubException, match='The action was neither triggered on release event, neither with dry_run=true'):
+        GitHub()
+
+
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'push', 'DRY_RUN': 'false'}, clear=True)
+def test_must_not_fail_on_non_release_event_given_dry_run_is_false():
+    with pytest.raises(GitHubException, match='The action was neither triggered on release event, neither with dry_run=true'):
+        GitHub()
+
+
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'push', 'DRY_RUN': ''}, clear=True)
+def test_must_not_fail_on_non_release_event_given_dry_run_is_undefined():
+    with pytest.raises(GitHubException, match='The action was neither triggered on release event, neither with dry_run=true'):
         GitHub()
 
 
@@ -38,7 +50,6 @@ def test_must_fail_if_tag_not_following_version_pattern(mock_release_event):
        })
 def test_must_succeed_with_correct_tag(mock_release_event):
     with patch('release.utils.github.open', mock_open()) as open_mock:
-
         release_request = GitHub().get_release_request()
         assert release_request.org == 'org'
         assert release_request.project == 'project'
@@ -63,7 +74,6 @@ def test_must_succeed_with_correct_tag(mock_release_event):
        })
 def test_must_succeed_with_target_commitish_containing_a_commit(mock_release_event):
     with patch('release.utils.github.open', mock_open()) as open_mock:
-
         release_request = GitHub().get_release_request()
         assert release_request.org == 'org'
         assert release_request.project == 'project'
@@ -111,3 +121,59 @@ def test_do_publish_to_binaries():
 
 def test_do_not_publish_to_binaries():
     assert not GitHub.is_publish_to_binaries()
+
+
+@patch.dict(os.environ, {
+    'GITHUB_EVENT_NAME': 'release',
+    'GITHUB_SHA': 'sha',
+    'INPUT_DRY_RUN': 'true'
+}, clear=True)
+@patch('release.utils.github.json.load',
+       return_value={
+           'repository': {
+               'full_name': 'org/project'
+           },
+           'release': {
+               'tag_name': '1.0.0.42',
+               'target_commitish': 'branch'
+           },
+       })
+def test_get_release_request_should_return_fake_release_request_given_dry_run_is_true(mock_release_event):
+    with patch('release.utils.github.open', mock_open()) as open_mock:
+        github = GitHub()
+        release_request = github.get_release_request()
+
+        fake_release_request = github._GitHub__fake_release_request()
+        print(fake_release_request)
+        assert release_request.org == fake_release_request.org
+        assert release_request.project == fake_release_request.project
+        assert release_request.version == fake_release_request.version
+        assert release_request.buildnumber == fake_release_request.buildnumber
+        assert release_request.branch == fake_release_request.branch
+        assert release_request.sha == fake_release_request.sha
+
+@patch.dict(os.environ, {
+    'GITHUB_EVENT_NAME': 'release',
+    'GITHUB_SHA': 'sha',
+    'INPUT_DRY_RUN': 'false'
+}, clear=True)
+@patch('release.utils.github.json.load',
+       return_value={
+           'repository': {
+               'full_name': 'org/project'
+           },
+           'release': {
+               'tag_name': '1.0.0.42',
+               'target_commitish': 'branch'
+           },
+       })
+def test_get_release_request_should_not_return_fake_release_request_given_dry_run_is_false(mock_release_event):
+    with patch('release.utils.github.open', mock_open()) as open_mock:
+        github = GitHub()
+        release_request = github.get_release_request()
+
+        fake_release_request = github._GitHub__fake_release_request()
+        print(fake_release_request)
+        assert release_request.version != fake_release_request.version
+        assert release_request.buildnumber != fake_release_request.buildnumber
+        assert release_request.branch != fake_release_request.branch

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -128,7 +128,7 @@ class MainTest(unittest.TestCase):
                 set_output.assert_has_calls([call('releasability', 'done'), call('promote', 'done'), call('publish_to_binaries', 'done')])
 
     @parameterized.expand([
-        "BURGRX_USER", "BURGRX_PASSWORD", "ARTIFACTORY_ACCESS_TOKEN", "BINARIES_AWS_DEPLOY"
+        "BURGRX_USER", "BURGRX_PASSWORD", "ARTIFACTORY_ACCESS_TOKEN"
     ])
     def test_check_params_should_raise_an_exception_given_a_mandatory_env_variable_is_not_provided(self, parameter_not_provided):
         for variable_name in mandatory_env_variables:
@@ -152,12 +152,29 @@ class MainTest(unittest.TestCase):
         with self.assertRaises(InvalidInputParametersException):
             check_params()
 
+    def test_check_params_should_raise_an_exception_given_publish_to_binaries_is_true_and_binaries_aws_is_undefined(self):
+
+        for variable_name in mandatory_env_variables:
+            os.environ[variable_name] = "some value"
+
+        os.environ["INPUT_PUBLISH_TO_BINARIES"] = "true"
+
+        # ensure binaries_aws_deploy is not provided:
+        os.environ["BINARIES_AWS_DEPLOY"] = ""
+        del os.environ["BINARIES_AWS_DEPLOY"]
+
+        with self.assertRaises(InvalidInputParametersException):
+            check_params()
+
     def test_check_params_should_not_raise_an_exception_given_valid_inputs(self):
         for variable_name in mandatory_env_variables:
             os.environ[variable_name] = "some value"
 
         os.environ["INPUT_SLACK_CHANNEL"] = "some channel"
         os.environ["SLACK_API_TOKEN"] = "some channel"
+
+        os.environ["INPUT_PUBLISH_TO_BINARIES"] = "true"
+        os.environ["BINARIES_AWS_DEPLOY"] = "bin"
 
         try:
             check_params()

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -1,9 +1,12 @@
 import os
-from unittest.mock import patch, mock_open, ANY, call, Mock, MagicMock
+import unittest
+from unittest.mock import patch, mock_open, ANY, call
 
 import pytest
+from parameterized import parameterized
 
-from release.main import main, set_output, abort_release
+from release.exceptions.invalid_input_parameters_exception import InvalidInputParametersException
+from release.main import main, set_output, check_params, mandatory_env_variables
 from release.steps.ReleaseRequest import ReleaseRequest
 from release.utils.artifactory import Artifactory
 from release.utils.burgr import Burgr
@@ -17,44 +20,100 @@ def test_set_output(capfd):
     assert not err
 
 
-@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
-@patch('release.utils.github.json.load')
-@patch.object(Burgr, 'start_releasability_checks', side_effect=Exception('exception'))
-@patch('release.main.notify_slack')
-@patch.object(GitHub, 'revoke_release')
-def test_releasability_failure(github_revoke_release, notify_slack,
+class MainTest(unittest.TestCase):
+
+    @patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
+    @patch('release.main.check_params')
+    @patch('release.utils.github.json.load')
+    @patch.object(Burgr, 'start_releasability_checks', side_effect=Exception('exception'))
+    @patch('release.main.notify_slack')
+    @patch.object(GitHub, 'revoke_release')
+    def test_releasability_failure(self,
+                                   github_revoke_release,
+                                   notify_slack,
+                                   check_params,
+                                   burgr_start_releasability_checks,
+                                   github_event):
+        with patch('release.utils.github.open', mock_open()) as open_mock:
+            release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
+            with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
+                with pytest.raises(Exception, match='exception'):
+                    main()
+                    check_params.assert_called_once()
+                    open_mock.assert_called_once()
+                    github_event.assert_called_once()
+                    github_release_request.assert_called_once()
+                    burgr_start_releasability_checks.assert_called_once()
+                    notify_slack.assert_called_once_with('"Released project:version failed')
+                    github_revoke_release.assert_called_once()
+
+    @patch.dict(os.environ, {
+        'GITHUB_EVENT_NAME': 'release',
+        'ARTIFACTORY_ACCESS_TOKEN': 'mockArtifactoryAccessToken'
+    }, clear=True)
+    @patch('release.main.check_params')
+    @patch('release.utils.github.json.load')
+    @patch.object(Burgr, 'start_releasability_checks')
+    @patch.object(Burgr, 'get_releasability_status')
+    @patch.object(Artifactory, 'receive_build_info')
+    @patch.object(Artifactory, 'promote', side_effect=Exception('exception'))
+    @patch('release.main.notify_slack')
+    @patch('release.main.abort_release')
+    def test_promotion_failure(self,
+                               abort_release,
+                               notify_slack,
+                               check_params,
+                               artifactory_promote,
+                               artifactory_receive_build_info,
                                burgr_start_releasability_checks,
+                               burgr_get_releasability_status,
                                github_event):
-    with patch('release.utils.github.open', mock_open()) as open_mock:
-        release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
-        with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
-            with pytest.raises(Exception, match='exception'):
-                main()
-                open_mock.assert_called_once()
-                github_event.assert_called_once()
-                github_release_request.assert_called_once()
-                burgr_start_releasability_checks.assert_called_once()
-                notify_slack.assert_called_once_with('"Released project:version failed')
-                github_revoke_release.assert_called_once()
+        with patch('release.utils.github.open', mock_open()) as open_mock:
+            release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
+            with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
+                with pytest.raises(Exception, match='exception'):
+                    main()
+                    check_params.assert_called_once()
+                    open_mock.assert_called_once()
+                    github_event.assert_called_once()
+                    github_release_request.assert_called_once()
+                    burgr_start_releasability_checks.assert_called_once()
+                    burgr_get_releasability_status.assert_called_once()
+                    artifactory_receive_build_info.assert_called_once_with(release_request)
+                    artifactory_promote.assert_called_once_with(release_request, ANY)
+                    notify_slack.assert_called_once_with('"Released project:version failed')
+                    abort_release(ANY, ANY, ANY, release_request)
 
-
-@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
-@patch('release.utils.github.json.load')
-@patch.object(Burgr, 'start_releasability_checks')
-@patch.object(Burgr, 'get_releasability_status')
-@patch.object(Artifactory, 'receive_build_info')
-@patch.object(Artifactory, 'promote', side_effect=Exception('exception'))
-@patch('release.main.notify_slack')
-@patch('release.main.abort_release')
-def test_promotion_failure(abort_release, notify_slack,
-                           artifactory_promote, artifactory_receive_build_info,
-                           burgr_start_releasability_checks, burgr_get_releasability_status,
-                           github_event):
-    with patch('release.utils.github.open', mock_open()) as open_mock:
-        release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
-        with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
-            with pytest.raises(Exception, match='exception'):
+    @patch.dict(os.environ, {
+        'GITHUB_EVENT_NAME': 'release',
+        'ARTIFACTORY_ACCESS_TOKEN': 'mockAccessTokenValue',
+    }, clear=True)
+    @patch('release.utils.github.json.load')
+    @patch.object(Burgr, 'start_releasability_checks')
+    @patch.object(Burgr, 'get_releasability_status')
+    @patch.object(Artifactory, 'receive_build_info')
+    @patch.object(Artifactory, 'promote')
+    @patch.object(GitHub, 'is_publish_to_binaries', return_value=True)
+    @patch.object(Burgr, 'notify')
+    @patch('release.main.notify_slack')
+    @patch('release.main.set_output')
+    @patch('release.main.check_params')
+    def test_main_happy_path(self,
+                             check_params,
+                             set_output,
+                             notify_slack,
+                             burgr_notify,
+                             github_is_publish_to_binaries,
+                             artifactory_promote,
+                             artifactory_receive_build_info,
+                             burgr_start_releasability_checks,
+                             burgr_get_releasability_status,
+                             github_event):
+        with patch('release.utils.github.open', mock_open()) as open_mock:
+            release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
+            with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
                 main()
+                check_params.assert_called_once()
                 open_mock.assert_called_once()
                 github_event.assert_called_once()
                 github_release_request.assert_called_once()
@@ -62,39 +121,45 @@ def test_promotion_failure(abort_release, notify_slack,
                 burgr_get_releasability_status.assert_called_once()
                 artifactory_receive_build_info.assert_called_once_with(release_request)
                 artifactory_promote.assert_called_once_with(release_request, ANY)
-                notify_slack.assert_called_once_with('"Released project:version failed')
-                abort_release(ANY, ANY, ANY, release_request)
+                github_is_publish_to_binaries.assert_called_once()
+                burgr_notify.assert_called_once_with('passed')
+                notify_slack.assert_called_once_with('Successfully released project:version')
+                assert set_output.call_count == 3
+                set_output.assert_has_calls([call('releasability', 'done'), call('promote', 'done'), call('publish_to_binaries', 'done')])
 
+    @parameterized.expand([
+        "BURGRX_USER", "BURGRX_PASSWORD", "ARTIFACTORY_ACCESS_TOKEN", "BINARIES_AWS_DEPLOY"
+    ])
+    def test_check_params_should_raise_an_exception_given_a_mandatory_env_variable_is_not_provided(self, parameter_not_provided):
+        for variable_name in mandatory_env_variables:
+            os.environ[variable_name] = "some value"
+        del os.environ[parameter_not_provided]
 
-@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
-@patch('release.utils.github.json.load')
-@patch.object(Burgr, 'start_releasability_checks')
-@patch.object(Burgr, 'get_releasability_status')
-@patch.object(Artifactory, 'receive_build_info')
-@patch.object(Artifactory, 'promote')
-@patch.object(GitHub, 'is_publish_to_binaries', return_value=True)
-@patch.object(Burgr, 'notify')
-@patch('release.main.notify_slack')
-@patch('release.main.set_output')
-def test_main_happy_path(set_output, notify_slack,
-                         burgr_notify,
-                         github_is_publish_to_binaries,
-                         artifactory_promote, artifactory_receive_build_info,
-                         burgr_start_releasability_checks, burgr_get_releasability_status,
-                         github_event):
-    with patch('release.utils.github.open', mock_open()) as open_mock:
-        release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
-        with patch.object(GitHub, 'get_release_request', return_value=release_request) as github_release_request:
-            main()
-            open_mock.assert_called_once()
-            github_event.assert_called_once()
-            github_release_request.assert_called_once()
-            burgr_start_releasability_checks.assert_called_once()
-            burgr_get_releasability_status.assert_called_once()
-            artifactory_receive_build_info.assert_called_once_with(release_request)
-            artifactory_promote.assert_called_once_with(release_request, ANY)
-            github_is_publish_to_binaries.assert_called_once()
-            burgr_notify.assert_called_once_with('passed')
-            notify_slack.assert_called_once_with('Successfully released project:version')
-            assert set_output.call_count == 3
-            set_output.assert_has_calls([call('releasability', 'done'), call('promote', 'done'), call('publish_to_binaries', 'done')])
+        with self.assertRaises(InvalidInputParametersException):
+            check_params()
+
+    def test_check_params_should_raise_an_exception_given_slack_channel_is_provided_and_slack_token_is_not(self):
+
+        for variable_name in mandatory_env_variables:
+            os.environ[variable_name] = "some value"
+
+        os.environ["INPUT_SLACK_CHANNEL"] = "some channel"
+
+        # ensure slack api token is not provided:
+        os.environ["SLACK_API_TOKEN"] = ""
+        del os.environ["SLACK_API_TOKEN"]
+
+        with self.assertRaises(InvalidInputParametersException):
+            check_params()
+
+    def test_check_params_should_not_raise_an_exception_given_valid_inputs(self):
+        for variable_name in mandatory_env_variables:
+            os.environ[variable_name] = "some value"
+
+        os.environ["INPUT_SLACK_CHANNEL"] = "some channel"
+        os.environ["SLACK_API_TOKEN"] = "some channel"
+
+        try:
+            check_params()
+        except InvalidInputParametersException:
+            self.fail("check_params() raised an Exception")

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -6,7 +6,7 @@ import pytest
 from parameterized import parameterized
 
 from release.exceptions.invalid_input_parameters_exception import InvalidInputParametersException
-from release.main import main, set_output, check_params, mandatory_env_variables
+from release.main import main, set_output, check_params, MANDATORY_ENV_VARIABLES
 from release.steps.ReleaseRequest import ReleaseRequest
 from release.utils.artifactory import Artifactory
 from release.utils.burgr import Burgr
@@ -131,7 +131,7 @@ class MainTest(unittest.TestCase):
         "BURGRX_USER", "BURGRX_PASSWORD", "ARTIFACTORY_ACCESS_TOKEN"
     ])
     def test_check_params_should_raise_an_exception_given_a_mandatory_env_variable_is_not_provided(self, parameter_not_provided):
-        for variable_name in mandatory_env_variables:
+        for variable_name in MANDATORY_ENV_VARIABLES:
             os.environ[variable_name] = "some value"
         del os.environ[parameter_not_provided]
 
@@ -140,7 +140,7 @@ class MainTest(unittest.TestCase):
 
     def test_check_params_should_raise_an_exception_given_slack_channel_is_provided_and_slack_token_is_not(self):
 
-        for variable_name in mandatory_env_variables:
+        for variable_name in MANDATORY_ENV_VARIABLES:
             os.environ[variable_name] = "some value"
 
         os.environ["INPUT_SLACK_CHANNEL"] = "some channel"
@@ -154,7 +154,7 @@ class MainTest(unittest.TestCase):
 
     def test_check_params_should_raise_an_exception_given_publish_to_binaries_is_true_and_binaries_aws_is_undefined(self):
 
-        for variable_name in mandatory_env_variables:
+        for variable_name in MANDATORY_ENV_VARIABLES:
             os.environ[variable_name] = "some value"
 
         os.environ["INPUT_PUBLISH_TO_BINARIES"] = "true"
@@ -167,7 +167,7 @@ class MainTest(unittest.TestCase):
             check_params()
 
     def test_check_params_should_not_raise_an_exception_given_valid_inputs(self):
-        for variable_name in mandatory_env_variables:
+        for variable_name in MANDATORY_ENV_VARIABLES:
             os.environ[variable_name] = "some value"
 
         os.environ["INPUT_SLACK_CHANNEL"] = "some channel"

--- a/main/tests/utils/dryrun_test.py
+++ b/main/tests/utils/dryrun_test.py
@@ -1,0 +1,50 @@
+import io
+import os
+import unittest
+from contextlib import redirect_stdout
+
+from parameterized import parameterized
+from release.utils.dryrun import DryRunHelper
+
+
+class DryRunUtilTest(unittest.TestCase):
+
+    @parameterized.expand([
+        "True", "true"
+    ])
+    def test_is_dry_run_enabled_should_return_true_given_input_is(self, parametrized_value):
+        os.environ["INPUT_DRY_RUN"] = parametrized_value
+
+        result = DryRunHelper.is_dry_run_enabled()
+
+        self.assertTrue(result)
+
+    @parameterized.expand([
+        "False", "false", "", "some"
+    ])
+    def test_is_dry_run_enabled_should_return_false_given_input_is(self, parametrized_value):
+        os.environ["INPUT_DRY_RUN"] = parametrized_value
+
+        result = DryRunHelper.is_dry_run_enabled()
+
+        self.assertFalse(result)
+
+    def test_init_should_print_disclaimer_given_dry_run_is_true(self):
+        os.environ["INPUT_DRY_RUN"] = "true"
+
+        with io.StringIO() as captured_output, redirect_stdout(captured_output):
+
+            DryRunHelper.init()
+
+            printed_text = captured_output.getvalue()
+            self.assertTrue(printed_text.startswith(DryRunHelper.disclaimer_message))
+
+    def test_init_should_not_print_disclaimer_given_dry_run_is_false(self):
+        os.environ["INPUT_DRY_RUN"] = "false"
+
+        with io.StringIO() as captured_output, redirect_stdout(captured_output):
+
+            DryRunHelper.init()
+
+            printed_text = captured_output.getvalue()
+            self.assertFalse(printed_text.startswith(DryRunHelper.disclaimer_message))

--- a/maven-central-sync/entrypoint.sh
+++ b/maven-central-sync/entrypoint.sh
@@ -7,6 +7,7 @@ NEXUS_URL="$2"
 STAGING_PROFILE_ID="$3"
 DO_RELEASE="$4"
 
+
 MVN_NEXUS_STAGING_CMD="mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:"
 DEFAULT_OPTS="-DnexusUrl=$NEXUS_URL -DserverId=ossrh"
 PROFILE_OPT="-DstagingProfileId=$STAGING_PROFILE_ID"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,5 @@ sonar.organization=sonarsource
 sonar.projectKey=SonarSource_gh-action_release
 sonar.python.version=3.10
 sonar.python.coverage.reportPaths=main/build/coverage.xml
-sonar.sources=main
-sonar.exclusions=main/tests/*
+sonar.sources=main/release
 sonar.tests=main/tests


### PR DESCRIPTION
# BUILD-2509 dry run option for gh-action_release

## Notes
This is a first step in order to help testing release pipelines before merging them.

## Changes
* Check input parameters before doing anything in main()
  That way, it will fail fast (I discovered the issue with it-tests.yml) this allow to check some business logic such as: slack token 
  required if you use a slack_channel etc.
* Introduce dry_run optional input parameter (disabled by default)
  That way, it can be used from gh actions pipelines
* Print a disclaimer in case dry run is enabled
  That way, it helps the users to identify why nothing happens
* Introduce it-test.yaml workflow
  That way, it is possible to test the current action within the current
  branch without releasing, and it also helps to ensure that changes are not breaking the gh-action_release

## Output demo
```
Checking gh-action_release input/output parameters ...

===
DRY RUN
gh-action_release has been invoked with input `dry_run=true`.
It won't do anything having impacts, but it will still report what would have been done.
===
    
Burgr.start_releasability_checks() (--dry-run)
Burgr.get_releasability_status() (--dry-run)
Artifactory.receive_build_info() (--dry-run)
Artifactory.promote() (--dry-run)
Burgr.notify() (--dry-run)
notify_slack(Successfully released gh-action_release:?.?.?.????) (--dry-run)
```

![image](https://user-images.githubusercontent.com/4329594/229492337-33c7c826-4d5d-4f80-bdeb-511ecf33870f.png)


## How did you test it ?

I deployed it on sonar-dummy and sonar-dummy-oss


### sonar-dummy
*  :heavy_check_mark: release (dry_run) workflow to demonstrate the dry_run option: https://github.com/SonarSource/sonar-dummy/actions/runs/4553271188/jobs/8029633537
*  :heavy_check_mark: release workflow (default): https://github.com/SonarSource/sonar-dummy/actions/runs/4561436459/jobs/8047388758

### sonar-dummy-oss (currently broken cannot test it WIP)
* :heavy_check_mark: release (dry_run) workflow to demonstrate the dry_run option: https://github.com/SonarSource/sonar-dummy-oss/actions/runs/4594785677
* :heavy_check_mark: release workflow (default):  https://github.com/SonarSource/sonar-dummy-oss/actions/runs/4596639732/jobs/8118355808

