### PR TITLE
BUILD-2540 Add missing required type on reusable workflow

### DIFF
--- a/.github/workflows/releasability-check.yaml
+++ b/.github/workflows/releasability-check.yaml
@@ -1,7 +1,12 @@
 ---
 name: Releasability Check
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      version:
+        description: Version to check releasability on
+        required: true
+        type: string
 
 jobs:
   releasability_check:


### PR DESCRIPTION
This was working before but now the contract is clear and the call dies early on unfulfilled parameters.