### PR TITLE
[BUILD-2703] Update action to no longer depend on set-output (deprecated)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,7 @@ jobs:
             development/aws/sts/downloads security_token | binaries_aws_security_token;
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove before merge
+        uses: SonarSource/gh-action_release/main@v5
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
@@ -100,7 +100,7 @@ jobs:
     name: Maven Central
     needs: release
     if: ${{ inputs.mavenCentralSync && inputs.dryRun != true }}
-    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove before merge
+    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@v5
     with:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Vault Secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@d1c1ab4ca5ad07fd9cdfe1eff038a39673dfca64  # tag=2.4.2-1
+        uses: SonarSource/vault-action-wrapper@f148a1075c1eff1db5ab474f96c206c5587172d3  # tag=2.5.0-3
         with:
           url: ${{ inputs.vaultAddr }}
           secrets: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,7 @@ jobs:
             development/aws/sts/downloads security_token | binaries_aws_security_token;
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@v5
+        uses: SonarSource/gh-action_release/main@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove before merge
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
@@ -100,7 +100,7 @@ jobs:
     name: Maven Central
     needs: release
     if: ${{ inputs.mavenCentralSync && inputs.dryRun != true }}
-    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/maven-central.yaml@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove before merge
     with:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -53,14 +53,14 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@v5
+        uses: SonarSource/gh-action_release/download-build@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove after merge
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@v5
+        uses: SonarSource/gh-action_release/maven-central-sync@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove after merge
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -40,7 +40,7 @@ jobs:
         run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@d1c1ab4ca5ad07fd9cdfe1eff038a39673dfca64  # tag=2.4.2-1
+        uses: SonarSource/vault-action-wrapper@f148a1075c1eff1db5ab474f96c206c5587172d3  # tag=2.5.0-3
         with:
           url: ${{ inputs.vaultAddr }}
           secrets:
@@ -49,7 +49,7 @@ jobs:
             development/kv/data/ossrh password | ossrh_password;
             development/kv/data/slack webhook | slack_webhook;
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@eb712d76540e5d1f3756303f30387657fb204e52  # tag=2.4.1-1
+        uses: SonarSource/jfrog-setup-wrapper@92f2e341560f69ccf1763e8efb73f69405545491  # tag=3.2.0-2
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
@@ -68,7 +68,7 @@ jobs:
           OSSRH_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ossrh_password }}
       - name: Notify on failure
         if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
-        uses: 8398a7/action-slack@a189acbf0b7ea434558662ae25a0de71df69a435  # tag=v3.14.0
+        uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8  # tag=v3.15.1
         with:
           status: failure
           fields: repo,author,eventName

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -53,14 +53,14 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove after merge
+        uses: SonarSource/gh-action_release/download-build@v5
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove after merge
+        uses: SonarSource/gh-action_release/maven-central-sync@v5
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/.github/workflows/releasability-check.yaml
+++ b/.github/workflows/releasability-check.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Vault Secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@d1c1ab4ca5ad07fd9cdfe1eff038a39673dfca64  # tag=2.4.2-1
+        uses: SonarSource/vault-action-wrapper@f148a1075c1eff1db5ab474f96c206c5587172d3  # tag=2.5.0-3
         with:
           secrets: |
             development/kv/data/burgr github_username | burgrx_username;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove before merge
     with:
       publishToBinaries: true
       mavenCentralSync: true # for OSS projects only

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@feature/svermeille/BUILD-2699-do-not-use-deprecated-set-output # TODO: remove before merge
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true
       mavenCentralSync: true # for OSS projects only

--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -1,3 +1,5 @@
+import os
+
 from dryable import Dryable
 from release.steps import ReleaseRequest
 from release.utils.artifactory import Artifactory
@@ -75,8 +77,16 @@ def publish_artifact(artifactory, binaries, artifact_to_publish, version, repo, 
         binaries.s3_upload(artifact_file, filename, gid, s3_aid, version)
 
 
-def set_output(function, output):
-    print(f"::set-output name={function}::{function} {output}")
+def set_output(output_name, value):
+    """Sets the GitHub Action output.
+
+    Keyword arguments:
+    output_name - The name of the output
+    value - The value of the output
+    """
+    if "GITHUB_OUTPUT" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as output_stream:
+            print(f"{output_name}={value}", file=output_stream)
 
 
 def releasability_checks(github: GitHub, burgr: Burgr, release_request: ReleaseRequest.ReleaseRequest):

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from unittest.mock import patch, mock_open, ANY, call
 
@@ -13,11 +14,13 @@ from release.utils.burgr import Burgr
 from release.utils.github import GitHub
 
 
-def test_set_output(capfd):
-    set_output('function', 'output')
-    out, err = capfd.readouterr()
-    assert out == "::set-output name=function::function output\n"
-    assert not err
+def test_set_output():
+    with tempfile.NamedTemporaryFile(suffix="", prefix=os.path.basename(__file__)) as temp_file:
+        os.environ['GITHUB_OUTPUT'] = temp_file.name
+
+        set_output('function', 'output')
+
+        assert temp_file.read().decode("utf-8").strip() == "function=output"
 
 
 class MainTest(unittest.TestCase):

--- a/maven-central-sync/entrypoint.sh
+++ b/maven-central-sync/entrypoint.sh
@@ -24,7 +24,7 @@ release="$MVN_NEXUS_STAGING_CMD:rc-release $DEFAULT_OPTS"
 # R3P0 is a magic string to ensure that the correct line is grepped
 STAGING_REPO=$($open -DopenedRepositoryMessageFormat="R3P0:%s" | grep "R3P0:" | cut -d: -f2)
 
-echo "::set-output name=repo=${STAGING_REPO}"
+echo "repo=${STAGING_REPO}" >> "$GITHUB_OUTPUT"
 
 $deploy -DstagingRepositoryId="$STAGING_REPO" -DrepositoryDirectory="$LOCAL_REPO_DIR"
 


### PR DESCRIPTION
# BUILD-2703 Update action to no longer depend on set-output (deprecated)

## Changes
* Update dependencies versions
   That way they use no longer set-output which is deprecated by Github for removal end of 
   May.

## How was it tested ?

* sonar-dummy: https://github.com/SonarSource/sonar-dummy/actions/runs/4881297855/jobs/8712228608
* sonar-dummy-oss: https://github.com/SonarSource/sonar-dummy-oss/actions/runs/4883364601/jobs/8714638426