### PR TITLE
fix(BUILD-3949): set jf exclusion parameter

### DIFF
--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@c08ed43ac288fd9850a07521e63157b53cad9296 # 5.1.1
+        uses: SonarSource/gh-action_release/download-build@188e9e3a66205559a26593bfbdbd7a743f9071ea
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}

--- a/download-build/action.yml
+++ b/download-build/action.yml
@@ -15,7 +15,7 @@ inputs:
   exclusions:
     description: 'Exclude pattern from downloaded files'
     required: false
-    default: ''
+    default: '-'
 runs:
   using: 'composite'
   steps:
@@ -29,7 +29,7 @@ runs:
       run: jfrog rt download
         --fail-no-op
         --build "${JFROG_DL_BUILD}"
-        "${JFROG_DL_EXCLUSIONS/?*/--exclusions="${JFROG_DL_EXCLUSIONS}"}"
+        --exclusions "${JFROG_DL_EXCLUSIONS}"
         "${JFROG_DL_REMOTE_REPO}/"
     - name: Download checksums
       shell: bash


### PR DESCRIPTION
The exclusion evaluated to an empty string, which was used as a
positional parameter, causing the last parameter to be interpreted as
the local path instead of the remote path.

The fix will exclude the "-" as a default, this file will never be
available to download.

https://github.com/SonarSource/sonar-dummy-oss/actions/runs/6704109915/job/18218120601