### PR TITLE
Add SonarLint Eclipse 8.1 to the composite update site

### DIFF
--- a/main/release/resources/compositeArtifacts.xml
+++ b/main/release/resources/compositeArtifacts.xml
@@ -5,8 +5,12 @@
   <properties size="1">
     <property name="p2.timestamp" value="NOW"/>
   </properties>
-  <children size="2">
+  <children size="3">
+    <!-- The last version supporting Java 8 as a runtime -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/6.2.0.37299/"/>
+    <!-- The last version supporting Java 11 as a runtime -->
+    <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/8.1.0.80220/"/>
+    <!-- The latest release -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/RELEASE"/>
   </children>
 </repository>

--- a/main/release/resources/compositeContent.xml
+++ b/main/release/resources/compositeContent.xml
@@ -5,8 +5,12 @@
   <properties size="1">
     <property name="p2.timestamp" value="NOW"/>
   </properties>
-  <children size="2">
+  <children size="3">
+    <!-- The last version supporting Java 8 as a runtime -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/6.2.0.37299/"/>
+    <!-- The last version supporting Java 11 as a runtime -->
+    <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/8.1.0.80220/"/>
+    <!-- The latest release -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/RELEASE"/>
   </children>
 </repository>


### PR DESCRIPTION
As a follow-up to https://community.sonarsource.com/t/eclipse-marketplace-sonar-lint-plugin-9-1/105533