### PR TITLE
BUILD-4036 Automate javadoc deployment

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -37,3 +37,4 @@ jobs:
       binariesS3Bucket: test-bucket
       slackChannel: ""
       mavenCentralSync: false
+      publishJavadoc: false

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -1,0 +1,104 @@
+# yamllint disable rule:line-length
+---
+name: Javadoc publication
+"on":
+  workflow_call:
+    inputs:
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
+      javadocDestinationDirectory:
+        type: string
+        description: Name of the directory to use at https://javadocs.sonarsource.org/
+        required: true
+      vaultAddr:
+        type: string
+        description: Custom vault installation
+        default: https://vault.sonar.build:8200
+        required: false
+      artifactoryRoleSuffix:
+        type: string
+        description: artifactory reader suffix specified in vault repo config
+        default: private-reader
+        required: false
+
+jobs:
+  javadoc-publication:
+    name: Publish javadoc
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # to authenticate via OIDC
+      contents: read  # to revert a github release
+    timeout-minutes: 5
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    outputs:
+      javadoc-publication: ${{ steps.javadoc-publication-output.outcome }}
+    steps:
+      - name: Create local repository directory
+        id: local_repo
+        run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
+      - name: Vault
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@f148a1075c1eff1db5ab474f96c206c5587172d3  # tag=2.5.0-3
+        with:
+          url: ${{ inputs.vaultAddr }}
+          secrets:
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ inputs.artifactoryRoleSuffix }} access_token  | artifactory_access_token;
+            development/kv/data/slack webhook | slack_webhook;
+            development/aws/sts/javadocs access_key | javadoc_aws_access_key_id;
+            development/aws/sts/javadocs secret_key | javadoc_aws_secret_access_key;
+            development/aws/sts/javadocs security_token | javadoc_aws_security_token;
+      - name: Setup JFrog
+        uses: SonarSource/jfrog-setup-wrapper@92f2e341560f69ccf1763e8efb73f69405545491  # tag=3.2.0-2
+        with:
+          jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
+      - name: Download Artifacts
+        uses: SonarSource/gh-action_release/download-build@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        with:
+          flat-download: true
+          build-number: ${{ steps.get_version.outputs.build }}
+          local-repo-dir: ${{ steps.local_repo.outputs.dir }}
+      - name: Keep only javadoc.jar
+        run: find ${{ steps.local_repo.outputs.dir }} -type f ! -name "*-javadoc.jar" -delete
+      - name: List artifacts
+        run: ls ${{ steps.local_repo.outputs.dir }}
+      - name: Create javadoc dir
+        run: mkdir -p ${{ steps.local_repo.outputs.dir }}/javadoc/${{ github.event.release.tag_name }}
+      - name: Extract javadoc.jar
+        run: cd ${{ steps.local_repo.outputs.dir }} && mv *javadoc.jar javadoc.zip && unzip javadoc.zip -d javadoc/${{ github.event.release.tag_name }}
+      - name: List javadoc files
+        run: ls "${{ steps.local_repo.outputs.dir }}/javadoc/${{ github.event.release.tag_name }}"
+      - name: Publish javadoc files to S3
+        uses: SonarSource/gh-action_release/aws-s3@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        with:
+          command: cp
+          flags: --recursive
+          source: ${{ steps.local_repo.outputs.dir }}/javadoc
+          destination: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}
+          aws_access_key_id: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_access_key_id }}
+          aws_secret_access_key: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_secret_access_key }}
+          aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
+          aws_region: eu-central-1
+      - name: Delete dir named latest in S3
+        uses: SonarSource/gh-action_release/aws-s3@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        with:
+          command: rm
+          destination: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}/latest
+          aws_access_key_id: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_access_key_id }}
+          aws_secret_access_key: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_secret_access_key }}
+          aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
+          aws_region: eu-central-1
+        continue-on-error: true # the first time a project publish javadoc, there is no latest dir available
+      - name: Upload to dir named latest in S3
+        uses: SonarSource/gh-action_release/aws-s3@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        with:
+          command: cp
+          flags: --recursive
+          source: ${{ steps.local_repo.outputs.dir }}/javadoc/${{ github.event.release.tag_name }}/
+          destination: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}/latest
+          aws_access_key_id: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_access_key_id }}
+          aws_secret_access_key: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_secret_access_key }}
+          aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
+          aws_region: eu-central-1

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -11,8 +11,8 @@ name: Javadoc publication
         required: false
       javadocDestinationDirectory:
         type: string
-        description: Name of the directory to use at https://javadocs.sonarsource.org/
-        required: true
+        description: Name of the directory to use at https://javadocs.sonarsource.org/ (if not provided, use repository name)
+        required: false
       vaultAddr:
         type: string
         description: Custom vault installation
@@ -76,7 +76,7 @@ jobs:
           command: cp
           flags: --recursive
           source: ${{ steps.local_repo.outputs.dir }}/javadoc
-          destination: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}
+          destination: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory || github.event.repository.name }}
           aws_access_key_id: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_access_key_id }}
           aws_secret_access_key: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_secret_access_key }}
           aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        uses: SonarSource/gh-action_release/download-build@v5
         with:
           flat-download: true
           build-number: ${{ steps.get_version.outputs.build }}
@@ -71,7 +71,7 @@ jobs:
       - name: List javadoc files
         run: ls "${{ steps.local_repo.outputs.dir }}/javadoc/${{ github.event.release.tag_name }}"
       - name: Publish javadoc files to S3
-        uses: SonarSource/gh-action_release/aws-s3@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        uses: SonarSource/gh-action_release/aws-s3@v5
         with:
           command: cp
           flags: --recursive
@@ -82,7 +82,7 @@ jobs:
           aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
           aws_region: eu-central-1
       - name: Delete dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        uses: SonarSource/gh-action_release/aws-s3@v5
         with:
           command: rm
           destination: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}/latest
@@ -92,7 +92,7 @@ jobs:
           aws_region: eu-central-1
         continue-on-error: true # the first time a project publish javadoc, there is no latest dir available
       - name: Upload to dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        uses: SonarSource/gh-action_release/aws-s3@v5
         with:
           command: cp
           flags: --recursive

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,15 @@ on:
         description: Flag to enable the publication to binaries
         default: false
         required: false
+      publishJavadoc:
+        type: boolean
+        description: Flag to enable the javadoc publication
+        default: false
+        required: false
+      javadocDestinationDirectory:
+        type: string
+        description: Name of the directory to use at https://javadocs.sonarsource.org/ when publishJavadoc is set to true
+        required: false
       binariesS3Bucket:
         type: string
         description: Target bucket
@@ -96,7 +105,7 @@ jobs:
           echo "${ACTION_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@76b6e78551a9c02c9ab0506bd7e8559f138cc1e8 # 5.1.4
+        uses: SonarSource/gh-action_release/main@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
@@ -130,3 +139,14 @@ jobs:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       downloadExclusions: ${{ inputs.mavenCentralSyncExclusions }}
+
+  javadocPublication:
+    name: Javadoc publication
+    needs: release
+    if: ${{ inputs.publishJavadoc && inputs.dryRun != true }}
+    uses: ./.github/workflows/javadoc-publication.yaml
+    with:
+      dryRun: ${{ inputs.dryRun }}
+      vaultAddr: ${{ inputs.vaultAddr }}
+      artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
+      javadocDestinationDirectory: ${{ inputs.javadocDestinationDirectory }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "${ACTION_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
+        uses: SonarSource/gh-action_release/main@76b6e78551a9c02c9ab0506bd7e8559f138cc1e8 # 5.1.4
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ jobs:
 
 Available options:
 - publishToBinaries (default: false): enable the publication to binaries
+- publishJavadoc (default: false): enable the publication of the javadoc to https://javadocs.sonarsource.org/
+- javadocDestinationDirectory (required when publishJavadoc is true): define the subdir to use in https://javadocs.sonarsource.org/
 - binariesS3Bucket (default: downloads-cdn-eu-central-1-prod): target bucket
 - mavenCentralSync (default: false): enable synchronization to Maven Central, **for OSS projects only**
 - slackChannel (default: build): notification Slack channel

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
 Available options:
 - publishToBinaries (default: false): enable the publication to binaries
 - publishJavadoc (default: false): enable the publication of the javadoc to https://javadocs.sonarsource.org/
-- javadocDestinationDirectory (required when publishJavadoc is true): define the subdir to use in https://javadocs.sonarsource.org/
+- javadocDestinationDirectory (default: use repository name): define the subdir to use in https://javadocs.sonarsource.org/
 - binariesS3Bucket (default: downloads-cdn-eu-central-1-prod): target bucket
 - mavenCentralSync (default: false): enable synchronization to Maven Central, **for OSS projects only**
 - slackChannel (default: build): notification Slack channel

--- a/aws-s3/Dockerfile
+++ b/aws-s3/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazon/aws-cli:2.4.23
+
+WORKDIR /
+ADD ./ /
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/aws-s3/action.yml
+++ b/aws-s3/action.yml
@@ -1,0 +1,34 @@
+name: 'AWS S3 Github Action'
+description: 'This action allows to use commands similar to AWS S3 CLI.'
+author: 'RE Team'
+runs:
+  using: docker
+  image: Dockerfile
+inputs:
+  command:
+    description: "The command that will be performed. More info: https://docs.aws.amazon.com/cli/latest/reference/s3/#available-commands"
+    required: false
+  source:
+    description: "The file path that the file will be sourced from. This can be either a local file or S3 file. The S3 file should lead with s3://."
+    required: true
+  destination:
+    description: "The file path that the file will be place. This can be either a local file or S3 file. The S3 file should lead with s3://."
+    required: false
+  aws_access_key_id:
+    description: "The AWS access key part of your credentials. More info: https://docs.aws.amazon.com/cli/latest/reference/configure/"
+    required: false
+  aws_secret_access_key:
+    description: "The AWS access key part of your credentials. More info: https://docs.aws.amazon.com/cli/latest/reference/configure/"
+    required: false
+  aws_session_token:
+    description: "The AWS access key part of your credentials. More info: https://docs.aws.amazon.com/cli/latest/reference/configure/"
+    required: false
+  aws_region:
+    description: "This is the region of the bucket. S3 namespace is global but the bucket is regional."
+    required: false
+  metadata_service_timeout:
+    description: "The number of seconds to wait until the metadata service request times out. More info: https://docs.aws.amazon.com/cli/latest/reference/configure/"
+    required: false
+  flags:
+    description: "Additional query flags."
+    required: false

--- a/aws-s3/entrypoint.sh
+++ b/aws-s3/entrypoint.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+function usage_docs {
+  echo ""
+  echo "- uses: SonarSource/gh-action_release/aws-s3@v2"
+  echo "  with:"
+  echo "    command: cp"
+  echo "    source: ./local_file.txt"
+  echo "    destination: s3://yourbucket/folder/local_file.txt"
+  echo "    aws_access_key_id: \${{ secret.AWS_ACCESS_KEY_ID }}"
+  echo "    aws_secret_access_key: \${{ secret.AWS_SECRET_ACCESS_KEY }}"
+  echo "    aws_session_token: \${{ secret.AWS_SESSION_TOKEN }}"
+  echo ""
+}
+
+function get_configuration_settings {
+  if [ -z "$INPUT_AWS_ACCESS_KEY_ID" ]
+  then
+    echo "AWS Access Key Id was not provided. Using configuration from previous step."
+  else
+    aws configure set aws_access_key_id "$INPUT_AWS_ACCESS_KEY_ID"
+  fi
+
+  if [ -z "$INPUT_AWS_SECRET_ACCESS_KEY" ]
+  then
+    echo "AWS Secret Access Key was not provided. Using configuration from previous step."
+  else
+    aws configure set aws_secret_access_key "$INPUT_AWS_SECRET_ACCESS_KEY"
+  fi
+
+  if [ -z "$INPUT_AWS_SESSION_TOKEN" ]
+  then
+    echo "AWS Session Token was not provided. Using configuration from previous step."
+  else
+    aws configure set aws_session_token "$INPUT_AWS_SESSION_TOKEN"
+  fi
+
+  if [ -z "$INPUT_METADATA_SERVICE_TIMEOUT" ]
+  then
+    echo "Metadata service timeout was not provided. Using configuration from previous step."
+  else
+    aws configure set metadata_service_timeout "$INPUT_METADATA_SERVICE_TIMEOUT"
+  fi
+
+  if [ -z "$INPUT_AWS_REGION" ]
+  then
+    echo "AWS region not provided. Using configuration from previous step."
+  else
+    aws configure set region "$INPUT_AWS_REGION"
+  fi
+}
+
+function get_command {
+  VALID_COMMANDS=("sync" "mb" "rb" "ls" "cp" "mv" "rm")
+  COMMAND="cp"
+  if [ -z "$INPUT_COMMAND" ]
+  then
+    echo "Command not set using cp"
+  elif [[ ! ${VALID_COMMANDS[*]} =~ "$INPUT_COMMAND" ]]
+  then
+    echo ""
+    echo "Invalid command provided :: [$INPUT_COMMAND]"
+    usage_docs
+    exit 1
+  else
+    echo "Using provided command"
+    COMMAND=$INPUT_COMMAND
+  fi
+}
+
+function validate_source_and_destination {
+  if [ "$COMMAND" == "cp" ] || [ "$COMMAND" == "mv" ] || [ "$COMMAND" == "sync" ]
+  then
+    # Require source and target
+    if [ -z "$INPUT_SOURCE" ] && [ "$INPUT_DESTINATION" ]
+    then
+      echo ""
+      echo "Error: Requires source and destination."
+      usage_docs
+      exit 1
+    fi
+
+    # Verify at least one source or target have s3:// as prefix
+    # if [[] || []]
+    if [[ ! "$INPUT_SOURCE" =~ ^s3:// ]] && [[ ! "$INPUT_DESTINATION" =~ ^s3:// ]]
+    then
+      echo ""
+      echo "Error: Source or target must have s3:// as prefix."
+      usage_docs
+      exit 1
+    fi
+  else
+    # Require source
+    if [ -z "$INPUT_SOURCE" ]
+    then
+      echo "Error: Requires source."
+      usage_docs
+      exit 1
+    fi
+
+    # Verify at source has s3:// as prefix
+    if [[ ! $INPUT_SOURCE =~ ^s3:// ]]
+    then
+      echo "Error: Source must have s3:// as prefix."
+      usage_docs
+      exit 1
+    fi
+  fi
+}
+
+function main {
+  get_configuration_settings
+  get_command
+  validate_source_and_destination
+
+  aws --version
+
+  if [ "$COMMAND" == "cp" ] || [ "$COMMAND" == "mv" ] || [ "$COMMAND" == "sync" ]
+  then
+    echo aws s3 $COMMAND "$INPUT_SOURCE" "$INPUT_DESTINATION" $INPUT_FLAGS
+    aws s3 "$COMMAND" "$INPUT_SOURCE" "$INPUT_DESTINATION" $INPUT_FLAGS
+  else
+    echo aws s3 $COMMAND "$INPUT_SOURCE" $INPUT_FLAGS
+    aws s3 "$COMMAND" "$INPUT_SOURCE" $INPUT_FLAGS
+  fi
+}
+
+main

--- a/download-build/action.yml
+++ b/download-build/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Exclude pattern from downloaded files'
     required: false
     default: '-'
+  flat-download:
+    description: 'Set to true if you do not wish to have the Artifactory respository path structure created locally for your downloaded files'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -26,10 +30,12 @@ runs:
         JFROG_DL_BUILD: ${{ github.event.repository.name }}/${{ inputs.build-number }}
         JFROG_DL_EXCLUSIONS: ${{ inputs.exclusions }}
         JFROG_DL_REMOTE_REPO: ${{ inputs.remote-repo }}
+        JFROG_DL_OPTIONS: $([[ "${{ inputs.flat-download }}" == "true" ]] && echo "--flat" || echo "")
       run: jfrog rt download
         --fail-no-op
         --build "${JFROG_DL_BUILD}"
-        --exclusions "${JFROG_DL_EXCLUSIONS}"
+        --exclusions "${JFROG_DL_EXCLUSIONS}" \
+        "${JFROG_DL_OPTIONS}"
         "${JFROG_DL_REMOTE_REPO}/"
     - name: Download checksums
       shell: bash


### PR DESCRIPTION
# BUILD-4036 Automate javadoc deployment

![image](https://github.com/SonarSource/gh-action_release/assets/4329594/ac3b562b-461f-4fb7-939c-8ba449acb370)


## Changes

* Introduce a new param `flat-download` for ` gh-action_release/download-build` https://github.com/SonarSource/gh-action_release/pull/117/commits/9f56f2a3e13935b50428ab70854a414dad408bd7

* Create gh-action_release/aws-s3 407dbb7adf11d7fa3083843b7fadd00e1fe8095d
  This way we can perform S3 operations with convenience in a GitHub workflow 

* Create javadoc-publication triggerable workflow 0b99c2859e7c10960e1d62dfeb70069391f16054
  That way all the javadoc publication logic is centralized in a simple workflow

* Adapt gh-action_release to support publishJavadoc feature 399e818d62691cf9af10f82b6cf3ac36fa769730
  Introduce a new input `publishJavadoc`: <boolean> (default false)  and `javadocDestinationDirectory`: <string>
  That way if desired, a project can publish its javadoc automatically

## How was it tested ?

### Tested on project sonar-dummy-oss:

Dry run keep working:
  https://github.com/SonarSource/sonar-dummy-oss/actions/runs/7844362536

Formal run keep working:
  https://github.com/SonarSource/sonar-dummy-oss/actions/runs/7844362540
  
  We can see the javadoc being deployed here: https://javadocs.sonarsource.org/?prefix=sonar-dummy-oss/

## TODOS
- [x] Remove references to the current branch after reviews (should target the main branch not feature/svermeille/...) 