### PR TITLE
BUILD-4569 fix issue with maven central deployment

### DIFF
--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: SonarSource/gh-action_release/aws-s3@0ec30fe51c5d369993ce97bfc56e1029289c779c
         with:
           command: rm
-          destination: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}/latest
+          source: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}/latest
           aws_access_key_id: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_access_key_id }}
           aws_secret_access_key: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_secret_access_key }}
           aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -59,7 +59,7 @@ jobs:
             development/aws/sts/javadocs secret_key | javadoc_aws_secret_access_key;
             development/aws/sts/javadocs security_token | javadoc_aws_security_token;
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@92f2e341560f69ccf1763e8efb73f69405545491  # tag=3.2.0-2
+        uses: SonarSource/jfrog-setup-wrapper@5712613f9a6c0379b2f46b936b77f16fc0a56d79  # tag=3.2.2
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@0ec30fe51c5d369993ce97bfc56e1029289c779c
+        uses: SonarSource/gh-action_release/download-build@e9ec7b68cff3cbc3423b8e54616ce27427ab0e37
         with:
           flat-download: true
           build-number: ${{ steps.get_version.outputs.build }}
@@ -79,7 +79,7 @@ jobs:
       - name: List javadoc files
         run: ls "${{ steps.local_repo.outputs.dir }}/javadoc/${{ github.event.release.tag_name }}"
       - name: Publish javadoc files to S3
-        uses: SonarSource/gh-action_release/aws-s3@0ec30fe51c5d369993ce97bfc56e1029289c779c
+        uses: SonarSource/gh-action_release/aws-s3@e9ec7b68cff3cbc3423b8e54616ce27427ab0e37
         with:
           command: cp
           flags: --recursive
@@ -90,7 +90,7 @@ jobs:
           aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
           aws_region: eu-central-1
       - name: Delete dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@0ec30fe51c5d369993ce97bfc56e1029289c779c
+        uses: SonarSource/gh-action_release/aws-s3@e9ec7b68cff3cbc3423b8e54616ce27427ab0e37
         with:
           command: rm
           source: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory }}/latest
@@ -100,7 +100,7 @@ jobs:
           aws_region: eu-central-1
         continue-on-error: true # the first time a project publish javadoc, there is no latest dir available
       - name: Upload to dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@0ec30fe51c5d369993ce97bfc56e1029289c779c
+        uses: SonarSource/gh-action_release/aws-s3@e9ec7b68cff3cbc3423b8e54616ce27427ab0e37
         with:
           command: cp
           flags: --recursive

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "${ACTION_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@0ec30fe51c5d369993ce97bfc56e1029289c779c
+        uses: SonarSource/gh-action_release/main@e9ec7b68cff3cbc3423b8e54616ce27427ab0e37
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@0ec30fe51c5d369993ce97bfc56e1029289c779c
+        uses: SonarSource/gh-action_release/download-build@e9ec7b68cff3cbc3423b8e54616ce27427ab0e37
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
@@ -66,7 +66,7 @@ jobs:
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@0ec30fe51c5d369993ce97bfc56e1029289c779c
+        uses: SonarSource/gh-action_release/maven-central-sync@e9ec7b68cff3cbc3423b8e54616ce27427ab0e37
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/download-build/action.yml
+++ b/download-build/action.yml
@@ -36,7 +36,7 @@ runs:
         --build "${JFROG_DL_BUILD}"
         --exclusions "${JFROG_DL_EXCLUSIONS}"
         "${JFROG_DL_OPTIONS}"
-        "${JFROG_DL_REMOTE_REPO}/"
+        "${JFROG_DL_REMOTE_REPO}"
     - name: Download checksums
       shell: bash
       working-directory: ${{ inputs.local-repo-dir }}


### PR DESCRIPTION
# Changes
* Remove trailing slash causing wrong URL for retrieval of md5 sha1 sha256 files
* Fix /latest update for javadoc (rm command was failing silently)
* Update jfrog wrapper (out of legacy node 16)
* Update hash