### PR TITLE
BUILD-4608 Trigger releasability checks from GitHub action directly

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,6 +79,11 @@ jobs:
       publish_to_binaries: ${{ steps.release.outputs.publish_to_binaries }}
       release: ${{ steps.release.outputs.release }}
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-region: eu-central-1
+          role-to-assume: "arn:aws:iam::064493320159:role/ReleasbilityChecksCICDRole"
       - name: Vault Secrets
         id: secrets
         if: ${{ inputs.dryRun != true }}
@@ -115,7 +120,7 @@ jobs:
           echo "${ACTION_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/main@feat/svermeille/BUILD-4608-Trigger-releasability-checks-from-Github-action-by-sending-SNS-message
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
@@ -128,10 +133,10 @@ jobs:
           BURGRX_PASSWORD: ${{ steps.parse_vault.outputs.burgrx_password }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_API_TOKEN: ${{ steps.parse_vault.outputs.slack_api_token }}
-          AWS_ACCESS_KEY_ID: ${{ steps.parse_vault.outputs.binaries_aws_access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.parse_vault.outputs.binaries_aws_secret_access_key }}
-          AWS_SESSION_TOKEN: ${{ steps.parse_vault.outputs.binaries_aws_security_token }}
-          AWS_DEFAULT_REGION: eu-central-1
+          BINARIES_AWS_ACCESS_KEY_ID: ${{ steps.parse_vault.outputs.binaries_aws_access_key_id }}
+          BINARIES_AWS_SECRET_ACCESS_KEY: ${{ steps.parse_vault.outputs.binaries_aws_secret_access_key }}
+          BINARIES_AWS_SESSION_TOKEN: ${{ steps.parse_vault.outputs.binaries_aws_security_token }}
+          BINARIES_AWS_DEFAULT_REGION: eu-central-1
       - name: Release action results
         if: always()
         run: |

--- a/main/release/main.py
+++ b/main/release/main.py
@@ -8,6 +8,7 @@ from release.utils.binaries import Binaries
 from release.utils.burgr import Burgr
 from release.utils.dryrun import DryRunHelper
 from release.utils.github import GitHub
+from release.utils.releasability import Releasability
 from release.utils.release import publish_all_artifacts_to_binaries, releasability_checks, revoke_release, set_output
 from release.utils.slack import notify_slack
 from release.vars import binaries_bucket_name, burgrx_password, burgrx_url, burgrx_user
@@ -60,8 +61,9 @@ def main():
     github = GitHub()
     release_request = github.get_release_request()
 
+    releasability = Releasability(release_request)
     burgr = Burgr(burgrx_url, burgrx_user, burgrx_password, release_request)
-    releasability_checks(github, burgr, release_request)
+    releasability_checks(github, burgr, releasability, release_request)
 
     artifactory = Artifactory(os.environ.get('ARTIFACTORY_ACCESS_TOKEN'))
     buildinfo = artifactory.receive_build_info(release_request)

--- a/main/release/releasability_check.py
+++ b/main/release/releasability_check.py
@@ -1,5 +1,6 @@
 from release.utils.burgr import Burgr
 from release.utils.github import GitHub
+from release.utils.releasability import Releasability
 from release.utils.release import releasability_checks
 from release.vars import burgrx_url, burgrx_user, burgrx_password
 
@@ -7,7 +8,7 @@ from release.vars import burgrx_url, burgrx_user, burgrx_password
 def do_releasability_checks():
     github = GitHub()
     release_request = github.get_release_request()
-    releasability_checks(github, Burgr(burgrx_url, burgrx_user, burgrx_password, release_request), release_request)
+    releasability_checks(github, Burgr(burgrx_url, burgrx_user, burgrx_password, release_request), Releasability(release_request), release_request)
 
 
 if __name__ == "__main__":

--- a/main/release/releasability_check.py
+++ b/main/release/releasability_check.py
@@ -8,7 +8,9 @@ from release.vars import burgrx_url, burgrx_user, burgrx_password
 def do_releasability_checks():
     github = GitHub()
     release_request = github.get_release_request()
-    releasability_checks(github, Burgr(burgrx_url, burgrx_user, burgrx_password, release_request), Releasability(release_request), release_request)
+    burgr = Burgr(burgrx_url, burgrx_user, burgrx_password, release_request)
+    releasability = Releasability(release_request)
+    releasability_checks(github, burgr, releasability, release_request)
 
 
 if __name__ == "__main__":

--- a/main/release/utils/aws_ssm_parameter_helper.py
+++ b/main/release/utils/aws_ssm_parameter_helper.py
@@ -1,0 +1,18 @@
+from boto3 import Session
+
+
+class AwsSsmParameterNotFound(Exception):
+    pass
+
+
+class AwsSsmParameterHelper:
+
+    @staticmethod
+    def get_ssm_parameter_value(aws_session: Session, parameter_name: str) -> str:
+        parameter = aws_session.client('ssm').get_parameter(Name=parameter_name)
+
+        if parameter['Name'] == parameter_name:
+            value = parameter['Value']
+            return value
+        else:
+            raise AwsSsmParameterNotFound('Could not retrieve ssm parameter value for parameter name={}'.format(parameter_name))

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -8,6 +8,8 @@ from importlib import resources
 from release import resources as file_resources
 from xml.dom.minidom import parseString
 
+from release.vars import binaries_aws_region_name, binaries_aws_session_token, binaries_aws_secret_access_key, binaries_aws_access_key_id
+
 OSS_REPO = "Distribution"
 COMMERCIAL_REPO = "CommercialDistribution"
 DISTRIBUTION_ID_PROD = 'E2WHX4O0Y6Z6C6'
@@ -19,7 +21,13 @@ class Binaries:
 
     def __init__(self, binaries_bucket_name: str):
         self.binaries_bucket_name = binaries_bucket_name
-        self.client = boto3.client('s3')
+        binaries_session = boto3.Session(
+            aws_access_key_id=binaries_aws_access_key_id,
+            aws_secret_access_key=binaries_aws_secret_access_key,
+            aws_session_token=binaries_aws_session_token,
+            region_name=binaries_aws_region_name
+        )
+        self.client = binaries_session.client('s3')
 
     @staticmethod
     def get_binaries_repo(gid):

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -21,13 +21,14 @@ class Binaries:
 
     def __init__(self, binaries_bucket_name: str):
         self.binaries_bucket_name = binaries_bucket_name
-        binaries_session = boto3.Session(
+        self.binaries_session = boto3.Session(
             aws_access_key_id=binaries_aws_access_key_id,
             aws_secret_access_key=binaries_aws_secret_access_key,
             aws_session_token=binaries_aws_session_token,
             region_name=binaries_aws_region_name
         )
-        self.client = binaries_session.client('s3')
+        self.s3_client = self.binaries_session.client('s3')
+        self.cloudfront_client = self.binaries_session.client('cloudfront')
 
     @staticmethod
     def get_binaries_repo(gid):
@@ -40,10 +41,10 @@ class Binaries:
         root_bucket_key = self.get_file_bucket_key(aid, gid)
         file_bucket_key = f"{root_bucket_key}/{filename}"
 
-        self.client.upload_file(artifact_file, self.binaries_bucket_name, file_bucket_key)
+        self.s3_client.upload_file(artifact_file, self.binaries_bucket_name, file_bucket_key)
         print(f'uploaded {artifact_file} to s3://{self.binaries_bucket_name}/{file_bucket_key}')
         for checksum in self.upload_checksums:
-            self.client.upload_file(f'{artifact_file}.{checksum}', self.binaries_bucket_name, f'{file_bucket_key}.{checksum}')
+            self.s3_client.upload_file(f'{artifact_file}.{checksum}', self.binaries_bucket_name, f'{file_bucket_key}.{checksum}')
             print(f'uploaded {artifact_file}.{checksum} to s3://{self.binaries_bucket_name}/{file_bucket_key}.{checksum}')
 
         # SonarLint
@@ -71,7 +72,7 @@ class Binaries:
                     local_file = os.path.join(root, filename)
                     s3_file = os.path.join(version_bucket_key, os.path.relpath(local_file, tmpdirname))
                     print(f"upload {s3_file}")
-                    self.client.upload_file(local_file, self.binaries_bucket_name, s3_file)
+                    self.s3_client.upload_file(local_file, self.binaries_bucket_name, s3_file)
         print(f'uploaded content of {zip_file} to s3://{self.binaries_bucket_name}/{version_bucket_key}')
 
     def upload_sonarlint_p2_site(self, root_bucket_key, version_bucket_key):
@@ -89,15 +90,14 @@ class Binaries:
             with open(temp_file, 'w') as output:
                 document.writexml(output, encoding='UTF-8')
             composite_bucket_key = f"{root_bucket_key}/{composite_file}"
-            self.client.upload_file(temp_file, self.binaries_bucket_name, composite_bucket_key)
+            self.s3_client.upload_file(temp_file, self.binaries_bucket_name, composite_bucket_key)
             print(f'uploaded {composite_file} to s3://{self.binaries_bucket_name}/{composite_bucket_key}')
 
-    @staticmethod
-    def update_sonarlint_p2_site(distribution_id, version):
+    def update_sonarlint_p2_site(self, distribution_id, version):
         """
         Create CloudFront invalidation to update the cache of SonarLint Eclipse P2 update site files
         """
-        client = boto3.client('cloudfront')
+        client = self.cloudfront_client
         response = client.create_invalidation(
             DistributionId=distribution_id,
             InvalidationBatch={
@@ -118,7 +118,7 @@ class Binaries:
         root_bucket_key = self.get_file_bucket_key(aid, gid)
         bucket_key = f"{root_bucket_key}/{filename}"
 
-        self.client.delete_object(Bucket=self.binaries_bucket_name, Key=bucket_key)
+        self.s3_client.delete_object(Bucket=self.binaries_bucket_name, Key=bucket_key)
         print(f'deleted {bucket_key}')
 
         if aid == SONARLINT_AID:

--- a/main/release/utils/burgr.py
+++ b/main/release/utils/burgr.py
@@ -7,6 +7,7 @@ from polling import TimeoutException
 from requests.auth import HTTPBasicAuth
 from requests.models import Response
 from release.steps.ReleaseRequest import ReleaseRequest
+from release.utils.version_helper import VersionHelper
 
 
 class BurgrException(Exception):
@@ -37,11 +38,7 @@ class Burgr:
         self.url = url
         self.auth_header = HTTPBasicAuth(user, password)
         self.release_request = release_request
-        version = self.release_request.version
-        # SLVSCODE-specific
-        if self.release_request.project == 'sonarlint-vscode':
-            version = version.split('+')[0]
-        self.version = version
+        self.version = VersionHelper.as_standardized_version(release_request)
 
     # This will only work for a branch build, not a PR build
     # because a PR build notification needs `"pr_number": NUMBER` instead of `'branch': NAME`

--- a/main/release/utils/releasability.py
+++ b/main/release/utils/releasability.py
@@ -1,0 +1,18 @@
+from dryable import Dryable
+from release.steps.ReleaseRequest import ReleaseRequest
+
+
+class Releasability:
+    release_request: ReleaseRequest
+
+    def __init__(self, release_request):
+        self.release_request = release_request
+        version = self.release_request.version
+        # SLVSCODE-specific
+        if self.release_request.project == 'sonarlint-vscode':
+            version = version.split('+')[0]
+        self.version = version
+
+    @Dryable(logging_msg='{function}()')
+    def start_releasability_checks(self):
+        print(f"Starting releasability check: {self.release_request.project}#{self.version}")

--- a/main/release/utils/releasability.py
+++ b/main/release/utils/releasability.py
@@ -1,5 +1,9 @@
+import uuid
+import boto3
 from dryable import Dryable
 from release.steps.ReleaseRequest import ReleaseRequest
+from release.utils.version_helper import VersionHelper
+from release.vars import releasability_aws_region, releasability_env_type
 
 
 class Releasability:
@@ -7,12 +11,66 @@ class Releasability:
 
     def __init__(self, release_request):
         self.release_request = release_request
-        version = self.release_request.version
-        # SLVSCODE-specific
-        if self.release_request.project == 'sonarlint-vscode':
-            version = version.split('+')[0]
-        self.version = version
+
+        arn_topics = {
+            "Dev": {
+                "INPUT_TOPIC": "arn:aws:sns:eu-west-1:597611216173:Releasability-Dev-MessagingReleasabilityTrigger41B5D077-ytFNCS6b5yFa",
+                "OUTPUT_TOPIC": "arn:aws:sns:eu-west-1:597611216173:Releasability-Dev-MessagingReleasabilityResult1BF0D6BB-uVEUpOrhfpcm"
+            },
+            "Staging": {
+                "INPUT_TOPIC":
+                    "arn:aws:sns:eu-west-1:308147251410:Releasability-Staging-MessagingReleasabilityTrigger41B5D077-iSdypIfYu4x5",
+                "OUTPUT_TOPIC": "arn:aws:sns:eu-west-1:308147251410:Releasability-Staging-MessagingReleasabilityResult1BF0D6BB-99BdgYmfNHCp"
+            },
+            "Prod": {
+                "INPUT_TOPIC": "arn:aws:sns:eu-west-1:064493320159:Releasability-Prod-MessagingReleasabilityTrigger41B5D077-EjmsAMpmaj72",
+                "OUTPUT_TOPIC": "arn:aws:sns:eu-west-1:064493320159:Releasability-Prod-MessagingReleasabilityResult1BF0D6BB-Sv8YMUXuc4bh"
+            },
+        }
+
+        self.INPUT_TOPIC_ARN = arn_topics[releasability_env_type]["INPUT_TOPIC"]
+        self.OUTPUT_TOPIC_ARN = arn_topics[releasability_env_type]["OUTPUT_TOPIC"]
+        self.session = boto3.Session(region_name=releasability_aws_region)
 
     @Dryable(logging_msg='{function}()')
     def start_releasability_checks(self):
-        print(f"Starting releasability check: {self.release_request.project}#{self.version}")
+        standardized_version = VersionHelper.as_standardized_version(self.release_request)
+
+        print(f"Starting releasability check: {self.release_request.project}#{standardized_version}")
+
+        correlation_id = str(uuid.uuid4())
+        sns_request = self._build_sns_request(
+            correlation_id=correlation_id,
+            organization=self.release_request.org,
+            project_name=self.release_request.project,
+            branch_name=self.release_request.branch,
+            version=standardized_version,
+            revision=self.release_request.sha,
+            build_number=int(self.release_request.buildnumber)
+        )
+
+        response = self.session.client('sns').publish(
+            TopicArn=self.INPUT_TOPIC_ARN,
+            Message=str(sns_request),
+        )
+        print(f"Issued SNS message {response['MessageId']}; the request identifier is {correlation_id}")
+        return correlation_id
+
+    def _build_sns_request(self,
+                           correlation_id: str,
+                           organization: str,
+                           project_name: str,
+                           branch_name: str,
+                           revision: str,
+                           version: str,
+                           build_number: int):
+        sns_request = {
+            'uuid': correlation_id,
+            'responseToARN': self.OUTPUT_TOPIC_ARN,
+            'repoSlug': f'{organization}/{project_name}',
+            'version': version,
+            'vcsRevision': revision,
+            'artifactoryBuildNumber': build_number,
+            'branchName': branch_name
+        }
+        return sns_request

--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -4,6 +4,7 @@ from dryable import Dryable
 from release.steps import ReleaseRequest
 from release.utils.artifactory import Artifactory
 from release.utils.burgr import Burgr
+from release.utils.releasability import Releasability
 from release.utils.github import GitHub
 from release.utils.slack import notify_slack
 
@@ -89,8 +90,9 @@ def set_output(output_name, value):
             print(f"{output_name}={value}", file=output_stream)
 
 
-def releasability_checks(github: GitHub, burgr: Burgr, release_request: ReleaseRequest.ReleaseRequest):
+def releasability_checks(github: GitHub, burgr: Burgr, releasability: Releasability, release_request: ReleaseRequest.ReleaseRequest):
     try:
+        releasability.start_releasability_checks()
         burgr.start_releasability_checks()
         burgr.get_releasability_status()
         set_output("releasability", "done")  # There is no value to do it expect to not break existing workflows

--- a/main/release/utils/version_helper.py
+++ b/main/release/utils/version_helper.py
@@ -1,0 +1,13 @@
+from release.steps import ReleaseRequest
+
+
+class VersionHelper:
+
+    @staticmethod
+    def as_standardized_version(release_request: ReleaseRequest) -> str:
+        version = release_request.version
+        # SLVSCODE-specific
+        if release_request.project == 'sonarlint-vscode':
+            version = version.split('+')[0]
+
+        return version

--- a/main/release/vars.py
+++ b/main/release/vars.py
@@ -10,3 +10,11 @@ binaries_bucket_name = os.environ.get('BINARIES_AWS_DEPLOY')
 slack_token = os.environ.get('SLACK_API_TOKEN')
 slack_client = WebClient(slack_token)
 slack_channel = os.environ.get('INPUT_SLACK_CHANNEL') or None
+
+releasability_aws_region = "eu-west-1"
+releasability_env_type = os.environ.get('RELEASABILITY_ENV_TYPE', 'Prod')
+
+binaries_aws_access_key_id = os.environ.get('BINARIES_AWS_ACCESS_KEY_ID')
+binaries_aws_secret_access_key = os.environ.get('BINARIES_AWS_SECRET_ACCESS_KEY')
+binaries_aws_session_token = os.environ.get('BINARIES_AWS_SESSION_TOKEN')
+binaries_aws_region_name = os.environ.get('BINARIES_AWS_DEFAULT_REGION')

--- a/main/tests/burgr_test.py
+++ b/main/tests/burgr_test.py
@@ -11,6 +11,8 @@ from release.steps.ReleaseRequest import ReleaseRequest
 from release.utils.burgr import Burgr, ReleasabilityFailure
 from unittest.mock import mock_open
 
+from release.utils.releasability import Releasability
+
 
 class BurgrResponse:
     def __init__(self, status_code):
@@ -153,12 +155,14 @@ def test_get_latest_releasability_stage(response, result):
 )
 @patch.object(Burgr, "start_releasability_checks")
 @patch.object(Burgr, "get_releasability_status")
+@patch.object(Releasability, 'start_releasability_checks')
 def test_releasability_checks_script(
-    json_load_mock, burgr_start_releasability_checks, burgr_get_releasability_status
+    json_load_mock, burgr_start_releasability_checks, burgr_get_releasability_status, releasability_start_releasability_checks
 ):
     with patch("release.utils.github.open", mock_open()) as open_mock:
         do_releasability_checks()
         open_mock.assert_called_once()
         json_load_mock.assert_called_once()
+        releasability_start_releasability_checks.assert_called_once()
         burgr_start_releasability_checks.assert_called_once()
         burgr_get_releasability_status.assert_called_once()

--- a/main/tests/burgr_test.py
+++ b/main/tests/burgr_test.py
@@ -156,13 +156,22 @@ def test_get_latest_releasability_stage(response, result):
 @patch.object(Burgr, "start_releasability_checks")
 @patch.object(Burgr, "get_releasability_status")
 @patch.object(Releasability, 'start_releasability_checks')
+@patch.object(Releasability, '_get_input_topic_arn')
+@patch.object(Releasability, '_get_output_topic_arn')
 def test_releasability_checks_script(
-    json_load_mock, burgr_start_releasability_checks, burgr_get_releasability_status, releasability_start_releasability_checks
+    json_load_mock,
+    burgr_start_releasability_checks,
+    burgr_get_releasability_status,
+    releasability_start_releasability_checks,
+    releasability_get_input_topic_arn,
+    releasability_get_output_topic_arn
 ):
     with patch("release.utils.github.open", mock_open()) as open_mock:
         do_releasability_checks()
         open_mock.assert_called_once()
         json_load_mock.assert_called_once()
+        releasability_get_input_topic_arn.assert_called_once()
+        releasability_get_output_topic_arn.assert_called_once()
         releasability_start_releasability_checks.assert_called_once()
         burgr_start_releasability_checks.assert_called_once()
         burgr_get_releasability_status.assert_called_once()

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -30,6 +30,8 @@ class MainTest(unittest.TestCase):
     @patch('release.main.check_params')
     @patch('release.utils.github.json.load')
     @patch.object(Releasability, 'start_releasability_checks')
+    @patch.object(Releasability, '_get_input_topic_arn')
+    @patch.object(Releasability, '_get_output_topic_arn')
     @patch.object(Burgr, 'start_releasability_checks', side_effect=Exception('exception'))
     @patch('release.main.notify_slack')
     @patch.object(GitHub, 'revoke_release')
@@ -38,6 +40,8 @@ class MainTest(unittest.TestCase):
                                    notify_slack,
                                    check_params,
                                    releasability_start_releasability_checks,
+                                   releasability_get_input_topic_arn,
+                                   releasability_get_output_topic_arn,
                                    burgr_start_releasability_checks,
                                    github_event):
         with patch('release.utils.github.open', mock_open()) as open_mock:
@@ -49,6 +53,8 @@ class MainTest(unittest.TestCase):
                     open_mock.assert_called_once()
                     github_event.assert_called_once()
                     github_release_request.assert_called_once()
+                    releasability_get_input_topic_arn.assert_called_once()
+                    releasability_get_output_topic_arn.assert_called_once()
                     releasability_start_releasability_checks.assert_called_once()
                     burgr_start_releasability_checks.assert_called_once()
                     notify_slack.assert_called_once_with('"Released project:version failed')
@@ -59,6 +65,8 @@ class MainTest(unittest.TestCase):
     @patch('release.utils.github.json.load')
     @patch.object(Burgr, 'start_releasability_checks')
     @patch.object(Releasability, 'start_releasability_checks', side_effect=Exception('exception'))
+    @patch.object(Releasability, '_get_input_topic_arn')
+    @patch.object(Releasability, '_get_output_topic_arn')
     @patch('release.main.notify_slack')
     @patch.object(GitHub, 'revoke_release')
     def test_releasability_failure(self,
@@ -67,6 +75,8 @@ class MainTest(unittest.TestCase):
                                    check_params,
                                    burgr_start_releasability_checks,
                                    releasability_start_releasability_checks,
+                                   releasability_get_input_topic_arn,
+                                   releasability_get_output_topic_arn,
                                    github_event):
         with patch('release.utils.github.open', mock_open()) as open_mock:
             release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
@@ -77,6 +87,8 @@ class MainTest(unittest.TestCase):
                     open_mock.assert_called_once()
                     github_event.assert_called_once()
                     github_release_request.assert_called_once()
+                    releasability_get_input_topic_arn.assert_called_once()
+                    releasability_get_output_topic_arn.assert_called_once()
                     releasability_start_releasability_checks.assert_called_once()
                     burgr_start_releasability_checks.assert_called_once()
                     notify_slack.assert_called_once_with('"Released project:version failed')
@@ -89,6 +101,8 @@ class MainTest(unittest.TestCase):
     @patch('release.main.check_params')
     @patch('release.utils.github.json.load')
     @patch.object(Releasability, 'start_releasability_checks')
+    @patch.object(Releasability, '_get_input_topic_arn')
+    @patch.object(Releasability, '_get_output_topic_arn')
     @patch.object(Burgr, 'start_releasability_checks')
     @patch.object(Burgr, 'get_releasability_status')
     @patch.object(Artifactory, 'receive_build_info')
@@ -102,6 +116,8 @@ class MainTest(unittest.TestCase):
                                artifactory_promote,
                                artifactory_receive_build_info,
                                burgr_start_releasability_checks,
+                               releasability_get_input_topic_arn,
+                               releasability_get_output_topic_arn,
                                relesability_start_releasability_checks,
                                burgr_get_releasability_status,
                                github_event):
@@ -115,6 +131,8 @@ class MainTest(unittest.TestCase):
                     github_event.assert_called_once()
                     github_release_request.assert_called_once()
                     relesability_start_releasability_checks.assert_called_once()
+                    releasability_get_input_topic_arn.assert_called_once()
+                    releasability_get_output_topic_arn.assert_called_once()
                     burgr_start_releasability_checks.assert_called_once()
                     burgr_get_releasability_status.assert_called_once()
                     artifactory_receive_build_info.assert_called_once_with(release_request)
@@ -128,6 +146,8 @@ class MainTest(unittest.TestCase):
     }, clear=True)
     @patch('release.utils.github.json.load')
     @patch.object(Releasability, 'start_releasability_checks')
+    @patch.object(Releasability, '_get_input_topic_arn')
+    @patch.object(Releasability, '_get_output_topic_arn')
     @patch.object(Burgr, 'start_releasability_checks')
     @patch.object(Burgr, 'get_releasability_status')
     @patch.object(Artifactory, 'receive_build_info')
@@ -148,6 +168,8 @@ class MainTest(unittest.TestCase):
                              burgr_start_releasability_checks,
                              burgr_get_releasability_status,
                              releasability_start_releasability_checks,
+                             releasability_get_input_topic_arn,
+                             releasability_get_output_topic_arn,
                              github_event):
         with patch('release.utils.github.open', mock_open()) as open_mock:
             release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
@@ -159,6 +181,8 @@ class MainTest(unittest.TestCase):
                 github_release_request.assert_called_once()
                 burgr_start_releasability_checks.assert_called_once()
                 releasability_start_releasability_checks.assert_called_once()
+                releasability_get_input_topic_arn.assert_called_once()
+                releasability_get_output_topic_arn.assert_called_once()
                 burgr_get_releasability_status.assert_called_once()
                 artifactory_receive_build_info.assert_called_once_with(release_request)
                 artifactory_promote.assert_called_once_with(release_request, ANY)

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -29,6 +29,7 @@ class MainTest(unittest.TestCase):
     @patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release'}, clear=True)
     @patch('release.main.check_params')
     @patch('release.utils.github.json.load')
+    @patch.object(Releasability, 'start_releasability_checks')
     @patch.object(Burgr, 'start_releasability_checks', side_effect=Exception('exception'))
     @patch('release.main.notify_slack')
     @patch.object(GitHub, 'revoke_release')
@@ -36,6 +37,7 @@ class MainTest(unittest.TestCase):
                                    github_revoke_release,
                                    notify_slack,
                                    check_params,
+                                   releasability_start_releasability_checks,
                                    burgr_start_releasability_checks,
                                    github_event):
         with patch('release.utils.github.open', mock_open()) as open_mock:
@@ -47,6 +49,7 @@ class MainTest(unittest.TestCase):
                     open_mock.assert_called_once()
                     github_event.assert_called_once()
                     github_release_request.assert_called_once()
+                    releasability_start_releasability_checks.assert_called_once()
                     burgr_start_releasability_checks.assert_called_once()
                     notify_slack.assert_called_once_with('"Released project:version failed')
                     github_revoke_release.assert_called_once()
@@ -63,7 +66,7 @@ class MainTest(unittest.TestCase):
                                    notify_slack,
                                    check_params,
                                    burgr_start_releasability_checks,
-                                   relesability_start_releasability_checks,
+                                   releasability_start_releasability_checks,
                                    github_event):
         with patch('release.utils.github.open', mock_open()) as open_mock:
             release_request = ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
@@ -74,7 +77,7 @@ class MainTest(unittest.TestCase):
                     open_mock.assert_called_once()
                     github_event.assert_called_once()
                     github_release_request.assert_called_once()
-                    relesability_start_releasability_checks.assert_called_once()
+                    releasability_start_releasability_checks.assert_called_once()
                     burgr_start_releasability_checks.assert_called_once()
                     notify_slack.assert_called_once_with('"Released project:version failed')
                     github_revoke_release.assert_called_once()
@@ -85,6 +88,7 @@ class MainTest(unittest.TestCase):
     }, clear=True)
     @patch('release.main.check_params')
     @patch('release.utils.github.json.load')
+    @patch.object(Releasability, 'start_releasability_checks')
     @patch.object(Burgr, 'start_releasability_checks')
     @patch.object(Burgr, 'get_releasability_status')
     @patch.object(Artifactory, 'receive_build_info')
@@ -98,6 +102,7 @@ class MainTest(unittest.TestCase):
                                artifactory_promote,
                                artifactory_receive_build_info,
                                burgr_start_releasability_checks,
+                               relesability_start_releasability_checks,
                                burgr_get_releasability_status,
                                github_event):
         with patch('release.utils.github.open', mock_open()) as open_mock:
@@ -109,6 +114,7 @@ class MainTest(unittest.TestCase):
                     open_mock.assert_called_once()
                     github_event.assert_called_once()
                     github_release_request.assert_called_once()
+                    relesability_start_releasability_checks.assert_called_once()
                     burgr_start_releasability_checks.assert_called_once()
                     burgr_get_releasability_status.assert_called_once()
                     artifactory_receive_build_info.assert_called_once_with(release_request)

--- a/main/tests/releasability_test.py
+++ b/main/tests/releasability_test.py
@@ -1,0 +1,80 @@
+import ast
+import unittest
+
+from unittest.mock import patch, MagicMock
+from boto3 import Session
+from release.steps.ReleaseRequest import ReleaseRequest
+from release.utils.releasability import Releasability
+
+
+class ReleasabilityTest(unittest.TestCase):
+
+    def test_build_sns_request_should_assign_correctly_properties(self):
+        organization = "sonar"
+        project_name = "sonar-dummy"
+        version = "5.4.3"
+        sha = "434343443efdcaaa123232"
+        build_number = 42
+        branch_name = "feat/some"
+
+        release_request = ReleaseRequest(organization, project_name, version, build_number, branch_name, sha)
+        releasability = Releasability(release_request)
+
+        uuid = "42f23-3232-3232-32232"
+
+        request = releasability._build_sns_request(
+            correlation_id=uuid,
+            organization=organization,
+            project_name=project_name,
+            branch_name=branch_name,
+            version=version,
+            revision=sha,
+            build_number=build_number
+        )
+
+        assert request['uuid'] == uuid
+        assert request['responseToARN'] is not None
+        assert request['repoSlug'] == "sonar/sonar-dummy"
+        assert request['version'] == version
+        assert request['vcsRevision'] == sha
+        assert request['artifactoryBuildNumber'] == build_number
+        assert request['branchName'] == branch_name
+
+    def test_start_releasability_checks_should_invoke_publish(self):
+        organization = "sonar"
+        project_name = "sonar-dummy"
+        version = "5.4.3"
+        sha = "434343443efdcaaa123232"
+        build_number = 42
+        branch_name = "feat/some"
+
+        release_request = ReleaseRequest(organization, project_name, version, build_number, branch_name, sha)
+        releasability = Releasability(release_request)
+
+        mocked_sns_client = MagicMock()
+
+        with patch.object(Session, 'client', return_value=mocked_sns_client):
+            releasability.start_releasability_checks()
+
+            assert mocked_sns_client.publish.call_count == 1
+            sns_query_content = ast.literal_eval(mocked_sns_client.publish.call_args[1]['Message'])
+            assert sns_query_content['responseToARN'] is not None
+            assert sns_query_content['vcsRevision'] == sha
+
+    def test_start_releasability_checks_should_return_a_correlation_id_after_invokation(self):
+        organization = "sonar"
+        project_name = "sonar-dummy"
+        version = "5.4.3"
+        sha = "434343443efdcaaa123232"
+        build_number = 42
+        branch_name = "feat/some"
+
+        release_request = ReleaseRequest(organization, project_name, version, build_number, branch_name, sha)
+        releasability = Releasability(release_request)
+
+        mocked_sns_client = MagicMock()
+
+        with patch.object(Session, 'client', return_value=mocked_sns_client):
+            correlation_id = releasability.start_releasability_checks()
+
+            assert correlation_id is not None

--- a/main/tests/utils/aws_ssm_parameter_helper_test.py
+++ b/main/tests/utils/aws_ssm_parameter_helper_test.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from release.utils.aws_ssm_parameter_helper import AwsSsmParameterHelper, AwsSsmParameterNotFound
+
+
+class AwsSsmParameterHelperTest(unittest.TestCase):
+
+    def test_get_ssm_parameter_value_should_return_arn_given_it_receives_a_valid_result(self):
+        parameter_name = "some param"
+        parameter_value = "arn:aws:ssm:us-east-1:whatever"
+
+        session = MagicMock()
+        session.client("ssm").get_parameter.return_value = {
+                    "Name": parameter_name,
+                    "Value": parameter_value
+        }
+        with patch('boto3.session', return_value=session):
+            result = AwsSsmParameterHelper.get_ssm_parameter_value(session, parameter_name)
+
+            assert result == parameter_value
+
+    def test_get_ssm_parameter_value_should_throw_an_exception_given_it_could_not_find_it(self):
+        parameter_name = "some param"
+
+        session = MagicMock()
+        session.client("ssm").get_parameters.return_value = {
+            "Parameters": []
+        }
+        with ((patch('boto3.session', return_value=session))):
+            self.assertRaises(AwsSsmParameterNotFound,
+                              AwsSsmParameterHelper.get_ssm_parameter_value,
+                              session,
+                              parameter_name
+                              )

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -103,8 +103,10 @@ def test_publish_artifact_s3_upload_sonarqube(buildinfo_sonarqube, capsys):
 
 
 def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
+    binaries_session = MagicMock()
     client = MagicMock()
-    with patch('boto3.client', return_value=client):
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
         artifactory = MagicMock(**{'download.return_value': "/tmp/dummy-1.0.2.456.jar"})
         binaries = Binaries("test_bucket")
         with patch.object(binaries, 'upload_sonarlint_unzip') as mock_upload_sonarlint_unzip, \
@@ -151,8 +153,10 @@ def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
 
 
 def test_publish_artifact_upload_file_sonarlint(buildinfo_sonarlint, capsys):
+    binaries_session = MagicMock()
     client = MagicMock()
-    with patch('boto3.client', return_value=client):
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
         artifactory = MagicMock(**{'download.return_value': "/tmp/org.sonarlint.eclipse.site-7.9.0.63244.zip"})
         binaries = Binaries("test_bucket")
         with patch.object(binaries, 'upload_sonarlint_unzip') as mock_upload_sonarlint_unzip, \

--- a/main/tests/utils/version_helper_test.py
+++ b/main/tests/utils/version_helper_test.py
@@ -1,0 +1,20 @@
+import unittest
+
+from parameterized import parameterized
+from release.steps.ReleaseRequest import ReleaseRequest
+from release.utils.version_helper import VersionHelper
+
+
+class VersionHelperTest(unittest.TestCase):
+
+    @parameterized.expand([
+        ('sonarlint-vscode', '1.2.3+4', '1.2.3'),
+        ('sonar-java', '1.2.3.4', '1.2.3.4')
+    ])
+    def test_as_standardized_version_should_return_expected_version(self, project: str, version: str, expected_version: str):
+        release_request = ReleaseRequest('SonarSource', project, version, 'buildnumber', 'branch', 'sha1')
+
+        actual_version = VersionHelper.as_standardized_version(release_request)
+
+        assert actual_version == expected_version
+


### PR DESCRIPTION
# BUILD-4608 Trigger releasability checks from GitHub action directly

## Changes

- [x] Keep Burgr working (retro compatibility) 
- [x] Trigger releasability checks directly without passing by burgr in parallel
- [x] Write Python unit tests
- [x] Use dynamic topic names

## How was it tested ?

- [x] Burgr keep triggered the releasability check (it should as we want to run it in parallel to keep it working):
     > I received a mail notification for that -> OK
- [x] A message is sent to the SNS trigger topic:

* https://github.com/SonarSource/sonar-dummy/actions/runs/8277511122

> sonar-dummy project targeted this same PR branch as gh-action_release version
  I could verify that the sns message were sent two times in the queue (once from burgr and once directly from the gh-action_release. (Subscribed to the SNS topic notifications on my email)

Here is what were sent to the ReleasabilityTriggerTopic right away from this feature:
```
{
  'uuid': 'a6171cc9-db79-4939-a0a1-a5c75fafa308', 
  'responseToARN': 'arn:aws:sns:eu-west-1:064493320159:Releasability-Prod-MessagingReleasabilityResult1BF0D6BB-Sv8YMUXuc4bh', 
  'repoSlug': 'SonarSource/sonar-dummy', 
  'version': '12.0.2.3456', 
  'vcsRevision': '67852a446bf4d7489139bfa69edaf2c2ec6e9798', 
  'artifactoryBuildNumber': 3456, 
  'branchName': 'master'
}
```
  

