### PR TITLE
BUILD-4644 Fix gh-action_release 5.2.0 do not download all required files anymore

### DIFF
--- a/.github/workflows/it-test-download-build.yml
+++ b/.github/workflows/it-test-download-build.yml
@@ -1,0 +1,76 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  it-tests-default-values:
+    name: IT Test - use default inputs values should generate expected output"
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Setup JFrog
+        uses: SonarSource/jfrog-setup-wrapper@5712613f9a6c0379b2f46b936b77f16fc0a56d79  # tag=3.2.2
+        with:
+          artifactoryRoleSuffix: "private-reader"
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 (Necessary to access local action)
+      - uses: ./download-build/
+        name: Given download-build is used with default values and dryRun enabled
+        id: test-data
+        with:
+          dryRun: true
+          build-number: '5432'
+          local-repo-dir: '.'
+          # use default values for the following:
+          #flat-download:
+          #exclusions:
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
+        name: Then outputs.jfrog_dl_options value must contains --flat, --exclusions and --dry-run
+        with:
+          expected: '--exclusions - --dry-run=true'
+          actual: ${{ steps.test-data.outputs.jfrog_dl_options }}
+          comparison: exact
+
+  it-tests-use-flat-download-true:
+    name: IT Test - use flat-download=true should generate expected output"
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Setup JFrog
+        uses: SonarSource/jfrog-setup-wrapper@5712613f9a6c0379b2f46b936b77f16fc0a56d79  # tag=3.2.2
+        with:
+          artifactoryRoleSuffix: "private-reader"
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 (Necessary to access local action)
+      - uses: ./download-build/
+        name: Given download-build is used with flat-download=true, exclusions and dryRun enabled
+        id: test-data
+        with:
+          dryRun: true
+          build-number: '5432'
+          flat-download: 'true'
+          exclusions: '-'
+          local-repo-dir: '.'
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
+        name: Then outputs.jfrog_dl_options value must contains --flat, --exclusions and --dry-run
+        with:
+          expected: '--exclusions - --dry-run=true --flat'
+          actual: ${{ steps.test-data.outputs.jfrog_dl_options }}
+          comparison: exact
+
+  it-tests:
+      name: "All IT Tests have to pass (download-build)"
+      runs-on: ubuntu-latest
+      if: always()
+      needs:
+        # Add your tests here so that they prevent the merge of broken changes
+        - it-tests-default-values
+        - it-tests-use-flat-download-true
+      steps:
+        - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+          with:
+            jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/download-build@fix/svermeille/BUILD-4644-gh-action_release-5.2.0-do-not-download-all-files-anymore
         with:
           flat-download: true
           build-number: ${{ steps.get_version.outputs.build }}

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@fix/svermeille/BUILD-4644-gh-action_release-5.2.0-do-not-download-all-files-anymore
+        uses: SonarSource/gh-action_release/download-build@v5
         with:
           flat-download: true
           build-number: ${{ steps.get_version.outputs.build }}

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@fix/svermeille/BUILD-4644-gh-action_release-5.2.0-do-not-download-all-files-anymore
+        uses: SonarSource/gh-action_release/download-build@v5
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/download-build@fix/svermeille/BUILD-4644-gh-action_release-5.2.0-do-not-download-all-files-anymore
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}

--- a/download-build/README.md
+++ b/download-build/README.md
@@ -1,0 +1,53 @@
+# Download REPOX build
+
+This action downloads all artifacts addressed by one build and one repository.
+The checksums of all files are stored beside.
+
+The resulting directory fits to the requirements to publish to maven central.
+
+## Usage
+
+### Download artifacts in tree dir format (required to deploy to maven central)
+
+```yaml
+on:
+  branch:
+    - master
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_release/download-build@0.0.1 <--- replace with last tag
+        with:
+          exclusions: '-'
+```
+
+### Download artifacts in flat format (used for javadoc deployment)
+
+```yaml
+on:
+  branch:
+    - master
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_release/download-build@0.0.1 <--- replace with last tag
+        with:
+          flat-download: true
+```
+
+## Options
+
+| Option name      | Description                                                                                                                | Default                       |
+|------------------|----------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `dryRun`         | Used to simulate a run of the action without effectively doing anything.                                                   | `false`                       |
+| `local-repo-dir` | Empty directory to store the artifacts                                                                                     | (required)                    |
+| `remote-repo`    | REPOX Repository to download from                                                                                          | `sonarsource-public-releases` |
+| `build-number`   | Build number                                                                                                               | (required)                    |
+| `exclusions`     | Exclude pattern from downloaded files                                                                                      | `-`                           |
+| `flat-download`  | Set to true if you do not wish to have the artifactory repository path structure created locally for your downloaded files | `false`                       |

--- a/download-build/action.yml
+++ b/download-build/action.yml
@@ -2,6 +2,11 @@
 name: 'Download build'
 description: 'Download all artifacts and checksums of a build'
 inputs:
+  dryRun:
+    type: boolean
+    description: Flag to enable the dry-run execution
+    default: false
+    required: false
   local-repo-dir:
     description: 'Empty directory to store the artifacts'
     required: true
@@ -17,27 +22,48 @@ inputs:
     required: false
     default: '-'
   flat-download:
-    description: 'Set to true if you do not wish to have the Artifactory respository path structure created locally for your downloaded files'
+    description: 'Set to true if you do not wish to have the Artifactory repository path structure created locally for your downloaded files'
     required: false
     default: 'false'
+outputs:
+  jfrog_dl_options:
+    description: Indicate which extra command is passed to jfrog for download
+    value: ${{ steps.define-download-options.outputs.jfrog_dl_options }}
 runs:
   using: 'composite'
   steps:
+    - name: Define download options
+      id: define-download-options
+      shell: bash
+      run: |
+        ARGS="--exclusions ${{ inputs.exclusions }}"
+        
+        if [ ${{ inputs.dryRun }} = 'true' ]; then
+            ARGS="$ARGS --dry-run=true"
+        fi
+        
+        if [ ${{ inputs.flat-download }} = 'true' ]; then
+            ARGS="$ARGS --flat"
+        fi
+        echo "jfrog_dl_options=$(echo $ARGS)" >> "$GITHUB_OUTPUT"
+    - name: Print download options
+      run: |
+        echo "JFrog download options: ${{ steps.define-download-options.outputs.jfrog_dl_options }}"
+      shell: bash
     - name: Download artifacts
+      if: ${{ inputs.dryRun != 'true' }}
       shell: bash
       working-directory: ${{ inputs.local-repo-dir }}
       env:
         JFROG_DL_BUILD: ${{ github.event.repository.name }}/${{ inputs.build-number }}
         JFROG_DL_EXCLUSIONS: ${{ inputs.exclusions }}
         JFROG_DL_REMOTE_REPO: ${{ inputs.remote-repo }}
-        JFROG_DL_OPTIONS: ${{ inputs.flat-download == 'true' && '--flat' || '' }}
       run: jfrog rt download
-        --fail-no-op
+        --fail-no-op ${{ steps.define-download-options.outputs.jfrog_dl_options }}
         --build "${JFROG_DL_BUILD}"
-        --exclusions "${JFROG_DL_EXCLUSIONS}"
-        "${JFROG_DL_OPTIONS}"
         "${JFROG_DL_REMOTE_REPO}"
     - name: Download checksums
+      if: ${{ inputs.dryRun != 'true' }}
       shell: bash
       working-directory: ${{ inputs.local-repo-dir }}
       env:

--- a/download-build/readme.md
+++ b/download-build/readme.md
@@ -1,6 +1,0 @@
-# Download build
-
-This action downloads all artifacts addressed by one build and one repository.
-The checksums of all files are stored beside.
-
-The resulting directory fits to the requirements to publish to maven central.


### PR DESCRIPTION
# BUILD-4644 Fix gh-action_release 5.2.0 do not download all required files anymore

## Changes
- [x] Converge `flat-download` and `exclusions` options properly
      That way they no longer generate extra spaces that cause `jfrog` command to be lost within the parsing. (Caused missing 
      downloaded files)
- [x] Implement some integration tests for download-build action
      That way we can prevent this to happen again in the future

![image](https://github.com/SonarSource/gh-action_release/assets/4329594/7c96af2a-7530-4f05-9dfe-a9abcacf86ec)


- [x] Document download-build action
## How was it tested ?

* Released sonar-dummy-oss using it https://github.com/SonarSource/sonar-dummy-oss/actions/runs/8250704862
     * maven-central sync download using `jfrog rt download --fail-no-op --exclusions - --build "${JFROG_DL_BUILD}" "${JFROG_DL_REMOTE_REPO}"`
     
    * javadoc-deploy download using `jfrog rt download --fail-no-op --exclusions - --flat --build "${JFROG_DL_BUILD}" "${JFROG_DL_REMOTE_REPO}"`

(no more undesired extra space)