### PR TITLE
BUILD-4650 Enable pre-commit check at CI level for github-action_release PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@0b086cbd326101c914f813f7d5790b8247d60f6c # 0.0.1
+        with:
+          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ What the dry run will do and not do:
 * Will not push binaries
 * Will not publish to slack
 
-Instead, it will actually print the sequence of operations that would have 
+Instead, it will actually print the sequence of operations that would have
 been performed based on the provided inputs defined in `with:` section.
 
 ## Versioning

--- a/aws-s3/entrypoint.sh
+++ b/aws-s3/entrypoint.sh
@@ -56,7 +56,7 @@ function get_command {
   if [ -z "$INPUT_COMMAND" ]
   then
     echo "Command not set using cp"
-  elif [[ ! ${VALID_COMMANDS[*]} =~ "$INPUT_COMMAND" ]]
+  elif [[ ! ${VALID_COMMANDS[*]} =~ $INPUT_COMMAND ]]
   then
     echo ""
     echo "Invalid command provided :: [$INPUT_COMMAND]"
@@ -117,11 +117,11 @@ function main {
 
   if [ "$COMMAND" == "cp" ] || [ "$COMMAND" == "mv" ] || [ "$COMMAND" == "sync" ]
   then
-    echo aws s3 $COMMAND "$INPUT_SOURCE" "$INPUT_DESTINATION" $INPUT_FLAGS
-    aws s3 "$COMMAND" "$INPUT_SOURCE" "$INPUT_DESTINATION" $INPUT_FLAGS
+    echo aws s3 "$COMMAND" "$INPUT_SOURCE" "$INPUT_DESTINATION" "$INPUT_FLAGS"
+    aws s3 "$COMMAND" "$INPUT_SOURCE" "$INPUT_DESTINATION" "$INPUT_FLAGS"
   else
-    echo aws s3 $COMMAND "$INPUT_SOURCE" $INPUT_FLAGS
-    aws s3 "$COMMAND" "$INPUT_SOURCE" $INPUT_FLAGS
+    echo aws s3 "$COMMAND" "$INPUT_SOURCE" "$INPUT_FLAGS"
+    aws s3 "$COMMAND" "$INPUT_SOURCE" "$INPUT_FLAGS"
   fi
 }
 

--- a/download-build/action.yml
+++ b/download-build/action.yml
@@ -3,9 +3,8 @@ name: 'Download build'
 description: 'Download all artifacts and checksums of a build'
 inputs:
   dryRun:
-    type: boolean
     description: Flag to enable the dry-run execution
-    default: false
+    default: 'false'
     required: false
   local-repo-dir:
     description: 'Empty directory to store the artifacts'
@@ -37,11 +36,11 @@ runs:
       shell: bash
       run: |
         ARGS="--exclusions ${{ inputs.exclusions }}"
-        
+
         if [ ${{ inputs.dryRun }} = 'true' ]; then
             ARGS="$ARGS --dry-run=true"
         fi
-        
+
         if [ ${{ inputs.flat-download }} = 'true' ]; then
             ARGS="$ARGS --flat"
         fi

--- a/main/tests/artifactory_test.py
+++ b/main/tests/artifactory_test.py
@@ -23,7 +23,7 @@ def buildinfo_multi():
             "timestampDate": 1662735041770
             }]
         }
-    })    
+    })
 
 
 @fixture
@@ -38,7 +38,7 @@ def buildinfo():
             "timestampDate": 1662735041770
             }]
         }
-    })    
+    })
 
 
 class RepoxResponse:
@@ -59,7 +59,7 @@ def test_notify(release_request):
         )
 
 
-def test_promote(release_request,buildinfo):    
+def test_promote(release_request,buildinfo):
     with patch('release.utils.artifactory.requests.post', return_value=RepoxResponse(200)) as request:
         Artifactory("token").promote(release_request,buildinfo)
         request.assert_called_once_with(
@@ -69,7 +69,7 @@ def test_promote(release_request,buildinfo):
         )
 
 
-def test_promote_revoke(release_request,buildinfo):    
+def test_promote_revoke(release_request,buildinfo):
     with patch('release.utils.artifactory.requests.post', return_value=RepoxResponse(200)) as request:
         Artifactory("token").promote(release_request,buildinfo,True)
         request.assert_called_once_with(
@@ -80,7 +80,7 @@ def test_promote_revoke(release_request,buildinfo):
 
 
 def test_multi_promote(release_request,buildinfo_multi):
-    with patch('release.utils.artifactory.requests.get', return_value=RepoxResponse(200)) as request:        
+    with patch('release.utils.artifactory.requests.get', return_value=RepoxResponse(200)) as request:
         Artifactory("token").promote(release_request,buildinfo_multi)
         request.assert_called_once_with(
             f"{Artifactory.url}/api/plugins/execute/multiRepoPromote?params="+
@@ -96,7 +96,7 @@ def test_multi_promote(release_request,buildinfo_multi):
 
 
 def test_multi_promote_revoke(release_request,buildinfo_multi):
-    with patch('release.utils.artifactory.requests.get', return_value=RepoxResponse(200)) as request:        
+    with patch('release.utils.artifactory.requests.get', return_value=RepoxResponse(200)) as request:
         Artifactory("token").promote(release_request,buildinfo_multi,True)
         request.assert_called_once_with(
             f"{Artifactory.url}/api/plugins/execute/multiRepoPromote?params="+
@@ -106,15 +106,15 @@ def test_multi_promote_revoke(release_request,buildinfo_multi):
                 "src1=sonarsource-private-releases;"+
                 "target1=sonarsource-private-builds;"+
                 "src2=sonarsource-public-releases;"+
-                "target2=sonarsource-public-builds", 
+                "target2=sonarsource-public-builds",
             headers={'content-type': 'application/json', 'Authorization': 'Bearer token'}
         )
 
 
 def test_download():
-    with patch('release.utils.artifactory.urllib.request.urlretrieve') as request:        
+    with patch('release.utils.artifactory.urllib.request.urlretrieve') as request:
         Artifactory("token").download('repo','gid','aid','qual','ext','version')
         request.assert_called_once_with(
-            f"{Artifactory.url}/repo/gid/aid/version/aid-version-qual.ext", 
+            f"{Artifactory.url}/repo/gid/aid/version/aid-version-qual.ext",
             f'{tempfile.gettempdir()}/aid-version-qual.ext'
         )


### PR DESCRIPTION
# BUILD-4650 Enable pre-commit check at CI level for github-action_release PRs

## Changes
* Add a workflow to trigger pre-commit checks at CI level
  That way it is no longer possible to merge changes that break pre-commit rules
* Fix all files having pre-commit issues
  That way we start on good basis