### PR TITLE
BUILD-4594: allow publishing to pypi

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,12 +55,12 @@ on:
         required: false
       publishToPyPI:
         type: boolean
-        description: Publish python artifacts to pypi.org
+        description: Publish Python artifacts to https://pypi.org
         default: false
         required: false
       publishToTestPyPI:
         type: boolean
-        description: Publish python artifacts to test.pypi.org
+        description: Publish Python artifacts to https://test.pypi.org
         default: false
         required: false
 
@@ -162,7 +162,7 @@ jobs:
       javadocDestinationDirectory: ${{ inputs.javadocDestinationDirectory }}
 
   testPypi:
-    name: Publish to TestPyPI
+    name: TestPyPI
     needs: release
     if: ${{ inputs.publishToTestPyPI && inputs.dryRun != true }}
     uses: ./.github/workflows/pypi.yaml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,6 +53,16 @@ on:
         description: exclusions for the jfrog build download
         default: "-"
         required: false
+      publishToPyPI:
+        type: boolean
+        description: Publish python artifacts to pypi.org
+        default: false
+        required: false
+      publishToTestPyPI:
+        type: boolean
+        description: Publish python artifacts to test.pypi.org
+        default: false
+        required: false
 
 jobs:
   release:
@@ -150,3 +160,23 @@ jobs:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       javadocDestinationDirectory: ${{ inputs.javadocDestinationDirectory }}
+
+  testPypi:
+    name: Publish to TestPyPI
+    needs: release
+    if: ${{ inputs.publishToTestPyPI && inputs.dryRun != true }}
+    uses: ./.github/workflows/pypi.yaml
+    with:
+      vaultAddr: ${{ inputs.vaultAddr }}
+      vaultTokenKey: pypi-test
+      artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
+      pypiRepoUrl: "https://test.pypi.org/legacy/"
+
+  pypi:
+    name: PyPi
+    needs: release
+    if: ${{ inputs.publishToPyPI && inputs.dryRun != true }}
+    uses: ./.github/workflows/pypi.yaml
+    with:
+      vaultAddr: ${{ inputs.vaultAddr }}
+      artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -4,7 +4,7 @@ name: PyPI
     inputs:
       vaultAddr:
         type: string
-        description: Custom vault installation
+        description: Custom Vault installation
         default: https://vault.sonar.build:8200
         required: false
       vaultTokenKey:
@@ -14,12 +14,12 @@ name: PyPI
         required: false
       artifactoryRoleSuffix:
         type: string
-        description: artifactory reader suffix specified in vault repo config
+        description: Artifactory reader suffix specified in vault repo config
         default: private-reader
         required: false
       downloadExclusions:
         type: string
-        description: exclusions for the jfrog build download
+        description: exclusions for the JFrog build download
         default: "-"
         required: false
       pypiRepoUrl:
@@ -30,7 +30,7 @@ name: PyPI
 
 jobs:
   pypi:
-    name: Push to PyPI
+    name: Publish to PyPI
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # to authenticate via OIDC

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,93 @@
+name: PyPI
+"on":
+  workflow_call:
+    inputs:
+      vaultAddr:
+        type: string
+        description: Custom vault installation
+        default: https://vault.sonar.build:8200
+        required: false
+      vaultTokenKey:
+        type: string
+        description: Vault key to read the token from
+        default: pypi
+        required: false
+      artifactoryRoleSuffix:
+        type: string
+        description: artifactory reader suffix specified in vault repo config
+        default: private-reader
+        required: false
+      downloadExclusions:
+        type: string
+        description: exclusions for the jfrog build download
+        default: "-"
+        required: false
+      pypiRepoUrl:
+        type: string
+        description: PyPI Repository URL for publishing the package
+        default: https://upload.pypi.org/legacy/
+        required: false
+
+jobs:
+  pypi:
+    name: Push to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # to authenticate via OIDC
+      contents: read  # to revert a github release
+    timeout-minutes: 30
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    outputs:
+      pypi: ${{ steps.pypi.outcome }}
+    steps:
+      - name: Get the version
+        id: get_version
+        run: |
+          IFS=. read -r major minor patch build <<< "${{ github.event.release.tag_name }}"
+          echo "build=${build}" >> $GITHUB_OUTPUT
+          echo "patch=${patch}" >> $GITHUB_OUTPUT
+          echo "minor=${minor}" >> $GITHUB_OUTPUT
+          echo "major=${major}" >> $GITHUB_OUTPUT
+      - name: Create local repository directory
+        id: local_repo
+        run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
+      - name: Vault
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@d0877ce7085bc313bd7a7b99c4e4489d42fb40e1 # tag=3.0.0
+        with:
+          url: ${{ inputs.vaultAddr }}
+          secrets:
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ inputs.artifactoryRoleSuffix }} access_token  | artifactory_access_token;
+            development/kv/data/{{ inputs.vaultTokenKey }} token | pypi_token;
+            development/kv/data/slack webhook | slack_webhook;
+      - name: Setup JFrog
+        uses: SonarSource/jfrog-setup-wrapper@5712613f9a6c0379b2f46b936b77f16fc0a56d79  # tag=3.2.2
+        with:
+          jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
+      - name: Download Artifacts
+        uses: SonarSource/gh-action_release/download-build@34b70fd193819eef88d223c324acfb54fcce8396
+        with:
+          build-number: ${{ steps.get_version.outputs.build }}
+          local-repo-dir: ${{ steps.local_repo.outputs.dir }}
+          exclusions: ${{ inputs.downloadExclusions }}
+          remote-repo: sonarsource-pypi-public-releases
+      - name: Publish to PyPI
+        id: publish-pypi
+        continue-on-error: true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ${{ steps.local_repo.outputs.dir }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).pypi_token }}
+          repository-url: ${{ inputs.pypiRepoUrl }}
+          print-hash: true
+      - name: Notify on failure
+        if: ${{ failure() }}
+        uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 # v3.16.2
+        with:
+          status: failure
+          fields: repo,author,eventName
+        env:
+          SLACK_WEBHOOK_URL: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
+      - name: Exit with error
+        if: ${{ failure() }}
+        run: exit 1

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -37,8 +37,6 @@ jobs:
       contents: read  # to revert a github release
     timeout-minutes: 30
     if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
-    outputs:
-      pypi: ${{ steps.pypi.outcome }}
     steps:
       - name: Get the version
         id: get_version

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Available options:
 - javadocDestinationDirectory (default: use repository name): define the subdir to use in https://javadocs.sonarsource.org/
 - binariesS3Bucket (default: downloads-cdn-eu-central-1-prod): target bucket
 - mavenCentralSync (default: false): enable synchronization to Maven Central, **for OSS projects only**
-- publishToPyPI (default: false): Publish pypi artifacts to https://pypi.org/ **for OSS projects only**
-- publishToTestPyPI (default: false): Publish pypi artifacts to https://test.pypi.org/ **for OSS projects only**
+- publishToPyPI (default: false): Publish pypi artifacts to https://pypi.org/, **for OSS projects only**
+- publishToTestPyPI (default: false): Publish pypi artifacts to https://test.pypi.org/, **for OSS projects only**
 - slackChannel (default: build): notification Slack channel
 - artifactoryRoleSuffix (default: promoter): Artifactory promoter suffix
 - dryRun (default: false): perform a dry run execution

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Available options:
 - javadocDestinationDirectory (default: use repository name): define the subdir to use in https://javadocs.sonarsource.org/
 - binariesS3Bucket (default: downloads-cdn-eu-central-1-prod): target bucket
 - mavenCentralSync (default: false): enable synchronization to Maven Central, **for OSS projects only**
+- publishToPyPI (default: false): Publish pypi artifacts to https://pypi.org/ **for OSS projects only**
+- publishToTestPyPI (default: false): Publish pypi artifacts to https://test.pypi.org/ **for OSS projects only**
 - slackChannel (default: build): notification Slack channel
 - artifactoryRoleSuffix (default: promoter): Artifactory promoter suffix
 - dryRun (default: false): perform a dry run execution
@@ -134,9 +136,19 @@ The following secrets and permissions are required:
 - development/aws/sts/downloads
 - secrets.GITHUB_TOKEN (provided by the GitHub Action runner)
 
-And if using `mavenCentralSync` option:
+Additionally,
+
+If using `mavenCentralSync` option:
 - development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader
 - development/kv/data/ossrh
+
+If using `publishToPyPI` option:
+- development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader
+- development/kv/data/pypi
+
+If using `publishToTestPyPI` option:
+- development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader
+- development/kv/data/pypi-test
 
 ## References
 


### PR DESCRIPTION
BUILD-4594

Added support for publishing python artifacts to pypi with two options:

* publishToPyPI : publish to pypi.org
* publishToTestPyPI: Publish to `test.pypi.org` (for testing purposes)