### PR TITLE
BUILD-4594: Allow specifying slack channel for pypi publish failure notification

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -171,6 +171,7 @@ jobs:
       vaultTokenKey: pypi-test
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       pypiRepoUrl: "https://test.pypi.org/legacy/"
+      slackChannel: ${{ inputs.slackChannel }}
 
   pypi:
     name: PyPi
@@ -180,3 +181,4 @@ jobs:
     with:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
+      slackChannel: ${{ inputs.slackChannel }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -27,6 +27,11 @@ name: PyPI
         description: PyPI Repository URL for publishing the package
         default: https://upload.pypi.org/legacy/
         required: false
+      slackChannel:
+        type: string
+        description: Slack channel to post notifications
+        default: build
+        required: false
 
 jobs:
   pypi:
@@ -84,6 +89,7 @@ jobs:
         with:
           status: failure
           fields: repo,author,eventName
+          channel: ${{ inputs.slackChannel }}
         env:
           SLACK_WEBHOOK_URL: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
       - name: Exit with error


### PR DESCRIPTION
BUILD-4594: Allow specifying slack channel for pypi publish failure notification