### PR TITLE
BUILD-2839: separate vault permissions for binary release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,6 +91,13 @@ jobs:
             development/kv/data/repox url | artifactory_url;
             development/kv/data/burgr github_username | burgrx_username;
             development/kv/data/burgr github_password | burgrx_password;
+      - name: Vault AWS Secrets
+        id: secrets-aws
+        if: ${{ inputs.dryRun != true && inputs.publishToBinaries }}
+        uses: SonarSource/vault-action-wrapper@d0877ce7085bc313bd7a7b99c4e4489d42fb40e1 # tag=3.0.0
+        with:
+          url: ${{ inputs.vaultAddr }}
+          secrets: |
             development/aws/sts/downloads access_key | binaries_aws_access_key_id;
             development/aws/sts/downloads secret_key | binaries_aws_secret_access_key;
             development/aws/sts/downloads security_token | binaries_aws_security_token;
@@ -98,7 +105,8 @@ jobs:
         id: parse_vault
         env:
           DUMMY_VALUES: ${{ inputs.dryRun }}
-          ACTION_OUTPUTS: ${{ toJson(steps.secrets.outputs) }}
+          SECRET_OUTPUTS: ${{ toJson(steps.secrets.outputs) }}
+          SECRET_AWS_OUTPUTS: ${{ toJson(steps.secrets-aws.outputs) }}
         run: |
           if [[ "${DUMMY_VALUES}" == "true" ]]; then
             {
@@ -112,7 +120,8 @@ jobs:
             } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          echo "${ACTION_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
+          echo "${SECRET_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
+          echo "${SECRET_AWS_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
       - name: Release
         id: release
         uses: SonarSource/gh-action_release/main@95eaa42a649490e6236043bbacbe5e90fccc054f

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -121,7 +121,9 @@ jobs:
             exit 0
           fi
           echo "${SECRET_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
-          echo "${SECRET_AWS_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
+          if [[ "${SECRET_AWS_OUTPUTS}" != "{}" ]]; then
+            echo "${SECRET_AWS_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
+          fi
       - name: Release
         id: release
         uses: SonarSource/gh-action_release/main@95eaa42a649490e6236043bbacbe5e90fccc054f

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,8 +91,8 @@ jobs:
             development/kv/data/repox url | artifactory_url;
             development/kv/data/burgr github_username | burgrx_username;
             development/kv/data/burgr github_password | burgrx_password;
-      - name: Vault AWS Secrets
-        id: secrets-aws
+      - name: Vault Binaries AWS Secrets
+        id: secrets-binaries-aws
         if: ${{ inputs.dryRun != true && inputs.publishToBinaries }}
         uses: SonarSource/vault-action-wrapper@d0877ce7085bc313bd7a7b99c4e4489d42fb40e1 # tag=3.0.0
         with:
@@ -106,7 +106,7 @@ jobs:
         env:
           DUMMY_VALUES: ${{ inputs.dryRun }}
           SECRET_OUTPUTS: ${{ toJson(steps.secrets.outputs) }}
-          SECRET_AWS_OUTPUTS: ${{ toJson(steps.secrets-aws.outputs) }}
+          SECRET_AWS_OUTPUTS: ${{ toJson(steps.secrets-binaries-aws.outputs) }}
         run: |
           if [[ "${DUMMY_VALUES}" == "true" ]]; then
             {

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -61,7 +61,7 @@ jobs:
           url: ${{ inputs.vaultAddr }}
           secrets:
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ inputs.artifactoryRoleSuffix }} access_token  | artifactory_access_token;
-            development/kv/data/{{ inputs.vaultTokenKey }} token | pypi_token;
+            development/kv/data/${{ inputs.vaultTokenKey }} token | pypi_token;
             development/kv/data/slack webhook | slack_webhook;
       - name: Setup JFrog
         uses: SonarSource/jfrog-setup-wrapper@5712613f9a6c0379b2f46b936b77f16fc0a56d79  # tag=3.2.2

--- a/README.md
+++ b/README.md
@@ -133,10 +133,12 @@ The following secrets and permissions are required:
 - development/kv/data/slack
 - development/kv/data/repox
 - development/kv/data/burgr
-- development/aws/sts/downloads
 - secrets.GITHUB_TOKEN (provided by the GitHub Action runner)
 
 Additionally,
+
+If using `publishToBinaries` option:
+- development/aws/sts/downloads
 
 If using `mavenCentralSync` option:
 - development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader


### PR DESCRIPTION
BUILD-2839: separate vault permissions for binary release

AWS permissions are only required for projects which needs to be published to s3. This PR separates this step into and runs it only if the flag `publishToBinaries` is set.