### PR TITLE
BUILD-4665: disable releasability checks for Python

### DIFF
--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -20,7 +20,7 @@ name: Javadoc publication
         required: false
       artifactoryRoleSuffix:
         type: string
-        description: artifactory reader suffix specified in vault repo config
+        description: Artifactory reader suffix specified in vault repo config
         default: private-reader
         required: false
 
@@ -63,7 +63,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@34b70fd193819eef88d223c324acfb54fcce8396
+        uses: SonarSource/gh-action_release/download-build@master
         with:
           flat-download: true
           build-number: ${{ steps.get_version.outputs.build }}
@@ -79,7 +79,7 @@ jobs:
       - name: List javadoc files
         run: ls "${{ steps.local_repo.outputs.dir }}/javadoc/${{ github.event.release.tag_name }}"
       - name: Publish javadoc files to S3
-        uses: SonarSource/gh-action_release/aws-s3@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/aws-s3@master
         with:
           command: cp
           flags: --recursive
@@ -90,7 +90,7 @@ jobs:
           aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
           aws_region: eu-central-1
       - name: Delete dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/aws-s3@master
         with:
           command: rm
           source: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory || github.event.repository.name }}/latest
@@ -100,7 +100,7 @@ jobs:
           aws_region: eu-central-1
         continue-on-error: true # the first time a project publish javadoc, there is no latest dir available
       - name: Upload to dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/aws-s3@master
         with:
           command: cp
           flags: --recursive

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ on:
         required: false
       mavenCentralSyncExclusions:
         type: string
-        description: exclusions for the jfrog build download
+        description: exclusions for the JFrog build download
         default: "-"
         required: false
       publishToPyPI:
@@ -61,6 +61,13 @@ on:
       publishToTestPyPI:
         type: boolean
         description: Publish Python artifacts to https://test.pypi.org
+        default: false
+        required: false
+      # Releasability checks are not fully implemented for Python projects
+      # This flag allows to skip releasability checks and allow releasing the artifacts. It is ignored for non-python projects
+      skipPythonReleasabilityChecks:
+        type: boolean
+        description: Skip releasability checks for Python projects
         default: false
         required: false
 
@@ -79,6 +86,10 @@ jobs:
       publish_to_binaries: ${{ steps.release.outputs.publish_to_binaries }}
       release: ${{ steps.release.outputs.release }}
     steps:
+      # Clone the repo; Only required for checking releasability prerequisites
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Vault Secrets
         id: secrets
         if: ${{ inputs.dryRun != true }}
@@ -124,9 +135,22 @@ jobs:
           if [[ "${SECRET_AWS_OUTPUTS}" != "{}" ]]; then
             echo "${SECRET_AWS_OUTPUTS}" | jq -r '.vault | fromjson | to_entries[] | (.key + "<<EOF\n" + .value + "\nEOF")' >> "${GITHUB_OUTPUT}"
           fi
+
+      - name: Releasability check prerequisites
+        id: releasability_prerequisites
+        env:
+          SKIP_PYTHON_RELEASABILITY_CHECKS: ${{ inputs.skipPythonReleasabilityChecks }}
+        run: |
+          # Skip releasability checks if the project contains pyproject.toml file
+          if test -f "pyproject.toml" && "$SKIP_PYTHON_RELEASABILITY_CHECKS" == "true"  ; then
+            echo "skip_releasability_checks=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "skip_releasability_checks=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/main@master
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
@@ -143,6 +167,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.parse_vault.outputs.binaries_aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.parse_vault.outputs.binaries_aws_security_token }}
           AWS_DEFAULT_REGION: eu-central-1
+          SKIP_RELEASABILITY_CHECKS: ${{ steps.releasability_prerequisites.outputs.skip_releasability_checks }}
       - name: Release action results
         if: always()
         run: |

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -1,22 +1,22 @@
 # yamllint disable rule:line-length
 ---
-name: maven Central
+name: Maven Central
 "on":
   workflow_call:
     inputs:
       vaultAddr:
         type: string
-        description: Custom vault installation
+        description: Custom Vault installation
         default: https://vault.sonar.build:8200
         required: false
       artifactoryRoleSuffix:
         type: string
-        description: artifactory reader suffix specified in vault repo config
+        description: Artifactory reader suffix specified in vault repo config
         default: private-reader
         required: false
       downloadExclusions:
         type: string
-        description: exclusions for the jfrog build download
+        description: exclusions for the JFrog build download
         default: "-"
         required: false
 
@@ -58,7 +58,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@34b70fd193819eef88d223c324acfb54fcce8396
+        uses: SonarSource/gh-action_release/download-build@master
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
@@ -66,7 +66,7 @@ jobs:
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@95eaa42a649490e6236043bbacbe5e90fccc054f
+        uses: SonarSource/gh-action_release/maven-central-sync@master
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # to authenticate via OIDC
-      contents: read  # to revert a github release
+      contents: read  # to revert a GitHub release
     timeout-minutes: 30
     if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
     steps:
@@ -68,16 +68,18 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@34b70fd193819eef88d223c324acfb54fcce8396
+        uses: SonarSource/gh-action_release/download-build@master
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
           exclusions: ${{ inputs.downloadExclusions }}
           remote-repo: sonarsource-pypi-public-releases
+          flat-download: true
+          download-checksums: false
       - name: Publish to PyPI
         id: publish-pypi
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # tag=v1.8.14
         with:
           packages-dir: ${{ steps.local_repo.outputs.dir }}
           password: ${{ fromJSON(steps.secrets.outputs.vault).pypi_token }}

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Available options:
 - javadocDestinationDirectory (default: use repository name): define the subdir to use in https://javadocs.sonarsource.org/
 - binariesS3Bucket (default: downloads-cdn-eu-central-1-prod): target bucket
 - mavenCentralSync (default: false): enable synchronization to Maven Central, **for OSS projects only**
+- mavenCentralSyncExclusions (default: none): exclude some artifacts from synchronization
 - publishToPyPI (default: false): Publish pypi artifacts to https://pypi.org/, **for OSS projects only**
 - publishToTestPyPI (default: false): Publish pypi artifacts to https://test.pypi.org/, **for OSS projects only**
+- skipPythonReleasabilityChecks (default: false): Skip releasability checks **for Python projects only**
 - slackChannel (default: build): notification Slack channel
 - artifactoryRoleSuffix (default: promoter): Artifactory promoter suffix
 - dryRun (default: false): perform a dry run execution

--- a/download-build/README.md
+++ b/download-build/README.md
@@ -19,7 +19,7 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: SonarSource/gh-action_release/download-build@0.0.1 <--- replace with last tag
+      - uses: SonarSource/gh-action_release/download-build@v5
         with:
           exclusions: '-'
 ```
@@ -36,18 +36,19 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: SonarSource/gh-action_release/download-build@0.0.1 <--- replace with last tag
+      - uses: SonarSource/gh-action_release/download-build@v5
         with:
           flat-download: true
 ```
 
 ## Options
 
-| Option name      | Description                                                                                                                | Default                       |
-|------------------|----------------------------------------------------------------------------------------------------------------------------|-------------------------------|
-| `dryRun`         | Used to simulate a run of the action without effectively doing anything.                                                   | `false`                       |
-| `local-repo-dir` | Empty directory to store the artifacts                                                                                     | (required)                    |
-| `remote-repo`    | REPOX Repository to download from                                                                                          | `sonarsource-public-releases` |
-| `build-number`   | Build number                                                                                                               | (required)                    |
-| `exclusions`     | Exclude pattern from downloaded files                                                                                      | `-`                           |
-| `flat-download`  | Set to true if you do not wish to have the artifactory repository path structure created locally for your downloaded files | `false`                       |
+| Option name          | Description                                                                                                                | Default                       |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `dryRun`             | Used to simulate a run of the action without effectively doing anything.                                                   | `false`                       |
+| `local-repo-dir`     | Empty directory to store the artifacts                                                                                     | (required)                    |
+| `remote-repo`        | REPOX Repository to download from                                                                                          | `sonarsource-public-releases` |
+| `build-number`       | Build number                                                                                                               | (required)                    |
+| `exclusions`         | Exclude pattern from downloaded files                                                                                      | `-`                           |
+| `flat-download`      | Set to true if you do not wish to have the Artifactory repository path structure created locally for your downloaded files | `false`                       |
+| `download-checksums` | Set to false if you want to skip downloading the checksums                                                                 | `true`                        |

--- a/download-build/action.yml
+++ b/download-build/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Set to true if you do not wish to have the Artifactory repository path structure created locally for your downloaded files'
     required: false
     default: 'false'
+  download-checksums:
+    description: 'Set to false if you want to skip downloading the checksums'
+    required: false
+    default: 'true'
 outputs:
   jfrog_dl_options:
     description: Indicate which extra command is passed to jfrog for download
@@ -62,7 +66,7 @@ runs:
         --build "${JFROG_DL_BUILD}"
         "${JFROG_DL_REMOTE_REPO}"
     - name: Download checksums
-      if: ${{ inputs.dryRun != 'true' }}
+      if: ${{ inputs.dryRun != 'true' && inputs.download-checksums == 'true' }}
       shell: bash
       working-directory: ${{ inputs.local-repo-dir }}
       env:

--- a/main/release/main.py
+++ b/main/release/main.py
@@ -61,7 +61,13 @@ def main():
     release_request = github.get_release_request()
 
     burgr = Burgr(burgrx_url, burgrx_user, burgrx_password, release_request)
-    releasability_checks(github, burgr, release_request)
+
+    # Allow skipping releasability checks in exceptional cases
+    # Eg: when the releasability checks are not implemented for a specific language
+    if os.environ.get('SKIP_RELEASABILITY_CHECKS') == "true":
+        set_output("releasability", "done")
+    else:
+        releasability_checks(github, burgr, release_request)
 
     artifactory = Artifactory(os.environ.get('ARTIFACTORY_ACCESS_TOKEN'))
     buildinfo = artifactory.receive_build_info(release_request)


### PR DESCRIPTION
BUILD-4665: disable releasability checks for Python

- [ ] Test with sonar-dummy to make sure that this doesn't break existing workflow for java projects