### PR TITLE
BUILD-4729 automate self release process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-
-# Example of a CODEOWNERS file:
-#   https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 *       @sonarsource/re-team

--- a/.github/autoapproval.yml
+++ b/.github/autoapproval.yml
@@ -1,0 +1,8 @@
+from_owner:
+  - tomverin
+  - sebastienvermeille
+  - matemoln
+  - julien-carsique-sonarsource
+  - jayadeep-km-sonarsource
+required_labels:
+  - auto-approve

--- a/.github/workflows/autoapproval.yml
+++ b/.github/workflows/autoapproval.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+    types: [opened, reopened, labeled, edited]
+    branches:
+      - 'releases/**'
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autoapproval:
+    runs-on: ubuntu-latest
+    name: Autoapproval
+    steps:
+      - uses: dkhmelenko/autoapproval@76e6fa8313951249b9477a855f0d09ad6510b696 # v1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,51 @@
 ---
 name: Release
-run-name: Release ${{ github.event.release.tag_name }}
-"on":
-  release:
-    types:
-      - published
-      - prereleased
-
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Release branch (master or branch-*)
+        required: true
+        type: string
+        default: master
+      version:
+        description: Release version
+        required: true
+        type: string
+      doRelease:
+        type: boolean
+        description: Do a release
+        default: false
+        required: true
+      updateVBranch:
+        type: boolean
+        description: Update the v* branch
+        default: false
+        required: true
 jobs:
-  update-release-branch:
-    name: Update release branch
+  release:
+    name: Release
+    if: ${{ inputs.doRelease == true }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: ${{ inputs.branch }}
           fetch-tags: true
-      - name: update release branch
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-          PRE_RELEASE: ${{ github.event.release.prerelease }}
-        run: |
-          GIT_OPTS=$([[ "${PRE_RELEASE}" == "true" ]] && echo "--dry-run")
-          branch="v${TAG%%.*}"
-          git update-ref -m "reset: update branch $branch to tag $TAG" "refs/heads/$branch" "$TAG"
-          git push "${GIT_OPTS}" origin HEAD:"refs/heads/$branch"
+      - name: release
+        run: scripts/release.sh ${{ inputs.branch }} ${{ inputs.version }}
+  update-v-branch:
+    name: Update the v* branch
+    if: ${{ inputs.updateVBranch == true }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-tags: true
+      - name: update v* branch
+        run: scripts/updatevbranch.sh ${{ inputs.version }}

--- a/README.md
+++ b/README.md
@@ -121,37 +121,51 @@ The development is done on `master` and the `branch-*` maintenance branches.
 
 ### Release
 
-Create a release from a maintained branches, then update the `v*` shortcut.
+Due to the circular dependency issue with GitHub Actions self-reference, the release process is a bit more complex, as described
+in [scripts/pull-request-body.txt](./scripts/pull-request-body.txt).
 
-Prepare a pull-request with the self-references updated to the current changeset:
+#### Tag and Release
 
-```shell
-next_version=5.3.1
-git checkout master
-git pull
-git checkout -b release/update-self-references
-git grep -Hl SonarSource/gh-action_release | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)master,\1${next_version},g"
-git commit -m "chore: update self-references to ${next_version}" -a
-next_ref=$(git show -s --pretty=format:'%H')
-git grep -Hl SonarSource/gh-action_release | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${next_version},\1${next_ref},g"
-git commit -m "chore: update self-references to $next_ref" -a
-git tag "$next_version"
-git checkout master -- .
-git commit -m "chore: update self-references to master" -a
-gh pr create # TO BE MERGED ON MASTER BEFORE ANY OTHER PR
-git push origin "$next_version"
+This is available on GitHub: https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml
+
+```bash
+scripts/release.sh <branch> <version>
 ```
 
-Browse to the [releases](https://github.com/SonarSource/gh-action_release/releases) page and create a new release from the new tag created
-above.
+This script will:
 
-The `v-` branch update is now automated by the [release.yml](.github/workflows/release.yml) workflow.
-The following manual steps are not required anymore:
+1. commit references the future tag
+2. commit references the previous commit
+3. tag this second commit
+4. commit references back to the branch
+5. generate a PR with those release commits and the release tag
+6. the PR should be automatically approved and fast-forward merged
+7. create a Release on GitHub
 
-```shell
-git fetch --tags
-git update-ref -m "reset: update branch v4 to tag 4.2.5" refs/heads/v4 4.2.5
-git push origin v4
+Example:
+
+```
+$ scripts/release.sh branch-2 2.0.0
+$ git log --graph --pretty="%H %s %d" branch-2 -3 --reverse
+* 1c42d553f38c91d92aaff793a67d48d62255f9be chore: update self-references to 2.0.0
+* 2082aca0c8aa7cb64320b3713391d3d1056aaec6 chore: update self-references to 1c42d553f38c91d92aaff793a67d48d62255f9be  (tag: 2.0.0)
+* 0000554720dc90f987a86a43531b8595f27ea53e chore: update self-references to branch-2  (origin/pull/158, origin/branch-2)
+```
+
+#### Update the v* Branch
+
+This is available on GitHub: https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml
+
+```bash
+scripts/updatevbranch.sh <version>
+```
+
+Example:
+
+```
+$ scripts/updatevbranch.sh 2.0.0
+$ git show -s --pretty=format:'%H%d' 2.0.0
+2082aca0c8aa7cb64320b3713391d3d1056aaec6 (tag: 2.0.0, origin/v2)
 ```
 
 ## Requirements

--- a/scripts/pull-request-body.txt
+++ b/scripts/pull-request-body.txt
@@ -1,0 +1,13 @@
+DO NOT MERGE with GitHub UI!
+
+This PR:
+- MUST be merged before any other PR
+- MUST be fast-forward merged (GitHub UI merge features DO NOT WORK)
+- will be auto-approved under conditions, but manual approval is still allowed
+
+This PR is used to work around the circular dependency issue with GitHub Actions self-reference.
+It is creating a commit to reference the future tag, then a commit to reference the previous commit, and finally a commit to revert and
+reference the main branch. The tag is created on the second commit.
+This way, the circular dependency is broken and the workflow call itself.
+
+CHANGELOG:

--- a/scripts/pull-request-body.txt
+++ b/scripts/pull-request-body.txt
@@ -5,7 +5,7 @@ This PR:
 - MUST be fast-forward merged (GitHub UI merge features DO NOT WORK)
 - will be auto-approved under conditions, but manual approval is still allowed
 
-This PR is used to work around the circular dependency issue with GitHub Actions self-reference.
+This PR is used to work around the versioning issue with reusable workflows referencing GitHub Actions in the same repository.
 It is creating a commit to reference the future tag, then a commit to reference the previous commit, and finally a commit to revert and
 reference the main branch. The tag is created on the second commit.
 This way, the circular dependency is broken and the workflow call itself.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Release a new version of the action
+# Usage: scripts/release.sh <branch> <version>
+set -xeuo pipefail
+
+type git gh jq >/dev/null
+branch=$1
+version=$2
+working_branch="release/update-self-references-${version}"
+git checkout "${branch}"
+git pull origin "${branch}"
+git checkout -b "$working_branch"
+git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${branch},\1${version},g"
+git commit -m "chore: update self-references to ${version}" -a
+next_ref=$(git show -s --pretty=format:'%H')
+git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${version},\1${next_ref},g"
+git commit -m "chore: update self-references to $next_ref" -a
+git tag "$version"
+git checkout "${branch}" -- .
+git commit -m "chore: update self-references to ${branch}" -a
+git log --pretty="%H %s %d" "${branch}".. --reverse >> scripts/pull-request-body.txt
+git push origin "$working_branch"
+git push origin "$version"
+gh pr create --base "${branch}" --title "Release $version" --body-file scripts/pull-request-body.txt -a @me --label auto-approve
+echo "Wait for PR approval..."
+while ! gh pr view --json reviewDecision --jq .reviewDecision | grep -q APPROVED; do
+  sleep 5
+done
+git fetch
+git checkout "${branch}"
+git merge --ff-only "$working_branch"
+git push origin "${branch}"
+gh release create "$version" -t "$version" --target "$(git show -s --pretty=format:'%H' "$version")" --verify-tag --generate-notes

--- a/scripts/updatevbranch.sh
+++ b/scripts/updatevbranch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Update the v* branch to the tag version
+# Usage: scripts/updatevbranch.sh <version>
+set -xeuo pipefail
+
+version=$1
+branch="v${version%%.*}"
+git fetch --tags
+git update-ref -m "reset: update branch $branch to tag $version" "refs/heads/$branch" "$version"
+git push origin "$branch:refs/heads/$branch"


### PR DESCRIPTION
Provide scripts to ease the self-release process working around the circular dependency issue.
Automate the self-release process with a manual GitHub workflow.

Tests:
- created dummy branch-2
- manually ran `scripts/release.sh branch-2 2.0.0` which:
  - created https://github.com/SonarSource/gh-action_release/pull/158 (manually approved)
  - merged the PR and created a 2.0.0 GitHub release
- manually ran `scripts/updatevbranch.sh 2.0.0` which:
  - updated `v2` to the tag `2.0.0`

Not tested:
- [.github/workflows/release.yml](https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml) manual workflow available on GitHub
- [.github/workflows/autoapproval.yml](https://github.com/SonarSource/gh-action_release/actions/workflows/autoapproval.yml) automating the PR approval

TODO after merge:
- test the two above
- cherry-pick on branch-5