### PR TITLE
feat(BUILD-4613): ability to run releasability checks in the release workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,12 +76,27 @@ on:
         required: false
 
 jobs:
+  check-releasability:
+    name: Check Releasability
+    runs-on: ubuntu-latest
+    steps:
+      - name: Releasability checks
+        uses: SonarSource/gh-action_releasability@BUILD-4613-Provide-a-way-to-trigger-releasability-checks-before-creating-a-release
+        id: releasability-checks
+        with:
+          organization: ${{ github.repository_owner }}
+          repository: ${{ github.event.repository.name }}
+          branch: ${{ github.event.ref }}
+          version: ${{ github.event.inputs.version }}
+          commit-sha: ${{ github.event.sha }}
+
   release:
     name: Release
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # to authenticate via OIDC
       contents: write  # to revert a github release
+    needs: check-releasability
     timeout-minutes: 30
     if: ${{ inputs.dryRun == true || github.event_name == 'release' && github.event.action == 'published' }}
     outputs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Releasability checks
-        uses: SonarSource/gh-action_releasability@BUILD-4613-Provide-a-way-to-trigger-releasability-checks-before-creating-a-release
+        uses: SonarSource/gh-action_releasability@feat/mm/build-4767
         id: releasability-checks
         with:
           organization: ${{ github.repository_owner }}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: SonarSource/gh-action_release/main@master
+        uses: SonarSource/gh-action_release/main@feat/mm/build-4613
         with:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -90,7 +90,7 @@ jobs:
           repository: ${{ github.event.repository.name }}
           branch: ${{ github.event.ref }}
           version: ${{ github.event.inputs.version }}
-          commit-sha: ${{ github.event.sha }}
+          commit-sha: ${{ github.event.ref }}
 
   release:
     name: Release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,6 +79,8 @@ jobs:
   check-releasability:
     name: Check Releasability
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Releasability checks
         uses: SonarSource/gh-action_releasability@feat/mm/build-4767

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,6 +70,10 @@ on:
         description: Skip releasability checks for Python projects
         default: false
         required: false
+      version:
+        type: string
+        description: Version to run releasability checks for in the format of MAJOR.MINOR.PATCH.BUILD
+        required: false
 
 jobs:
   release:


### PR DESCRIPTION
depends on https://github.com/SonarSource/gh-action_releasability/pull/4