### PR TITLE
SLE-844: SLE with Java 11 support

### DIFF
--- a/main/release/resources/compositeArtifacts.xml
+++ b/main/release/resources/compositeArtifacts.xml
@@ -5,11 +5,9 @@
   <properties size="1">
     <property name="p2.timestamp" value="NOW"/>
   </properties>
-  <children size="3">
+  <children size="2">
     <!-- The last version supporting Java 8 as a runtime -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/6.2.0.37299/"/>
-    <!-- The last version supporting Java 11 as a runtime -->
-    <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/8.1.0.80220/"/>
     <!-- The latest release -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/RELEASE"/>
   </children>

--- a/main/release/resources/compositeContent.xml
+++ b/main/release/resources/compositeContent.xml
@@ -5,11 +5,9 @@
   <properties size="1">
     <property name="p2.timestamp" value="NOW"/>
   </properties>
-  <children size="3">
+  <children size="2">
     <!-- The last version supporting Java 8 as a runtime -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/6.2.0.37299/"/>
-    <!-- The last version supporting Java 11 as a runtime -->
-    <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/8.1.0.80220/"/>
     <!-- The latest release -->
     <child location="https://binaries.sonarsource.com/SonarLint-for-Eclipse/releases/RELEASE"/>
   </children>


### PR DESCRIPTION
Due to the introduction of Sloop, we can support Java 11 IDEs despite the analyzers moving to Java 17. This will unblock (enterprise) users from using the newest version of SLE.
This will come with the next release of SLE 10.1, planned for Monday 22nd of April 2024.