### PR TITLE
BUILD-5212 Support javadoc publication for private repositories

### DIFF
--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -23,6 +23,10 @@ name: Javadoc publication
         description: Artifactory reader suffix specified in vault repo config
         default: private-reader
         required: false
+      publicRelease:
+        type: boolean
+        description: Indicate if the project is generating a public release or not
+        required: true
 
 jobs:
   javadoc-publication:
@@ -68,6 +72,7 @@ jobs:
           flat-download: true
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
+          remote-repo:  ${{ inputs.publicRelease == true && 'sonarsource-public-releases' || 'sonarsource-private-releases'}}
       - name: Keep only javadoc.jar
         run: find ${{ steps.local_repo.outputs.dir }} -type f ! -name "*-javadoc.jar" -delete
       - name: List artifacts

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,11 @@ on:
         type: string
         description: Name of the directory to use at https://javadocs.sonarsource.org/ when publishJavadoc is set to true
         required: false
+      publicRelease:
+        type: boolean
+        description: Indicate if the project is generating a public release or not
+        required: false
+        default: false
       binariesS3Bucket:
         type: string
         description: Target bucket
@@ -243,6 +248,7 @@ jobs:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       javadocDestinationDirectory: ${{ inputs.javadocDestinationDirectory }}
+      publicRelease: ${{ inputs.publicRelease }}
 
   testPypi:
     name: TestPyPI

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -100,7 +100,8 @@ jobs:
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
           # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          # ref: ${{ github.ref }}
+          ref: feat/svermeille/BUILD-5212-gh-action_release-Enhance-publish_javadoc-to-support-private-repositories
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Available options:
 
 - `publishToBinaries` (default: *false*): enable the publication to binaries
 - `publishJavadoc` (default: *false*): enable the publication of the javadoc to https://javadocs.sonarsource.org/
+  > Note: When the project is releasing a public release, `publicRelease: true` has to be set.
 - `javadocDestinationDirectory` (default: *use repository name*): define the subdir to use in https://javadocs.sonarsource.org/
+- `publicRelease` (default: *false*): define if the release is public or private (used by `publishJavadoc`)
 - `binariesS3Bucket` (default: *downloads-cdn-eu-central-1-prod*): target bucket
 - `mavenCentralSync` (default: *false*): enable synchronization to Maven Central, **for OSS projects only**
 - `mavenCentralSyncExclusions` (default: *none*): exclude some artifacts from synchronization
@@ -67,6 +69,12 @@ development/kv/data/repox
 
 ```
 development/aws/sts/downloads
+```
+
+#### Additional permissions if using `publishJavadoc`
+
+```
+development/aws/sts/javadocs
 ```
 
 #### Additional permissions if using `mavenCentralSync`


### PR DESCRIPTION
# BUILD-5212 Support javadoc publication for private repositories

## Changes

- [x]  Introduce publicRelease <true|false> (default false)
       That way publishJavadoc is able to retrieve artifacts and upload javadoc for private projects too
- [x]  Document new input and missing permissions requirements (discovered while testing with sonar-dummy)
       
## How was it tested?

- [x] Released sonar-dummy 14.0 using this same branch (private) https://github.com/SonarSource/sonar-dummy/releases/tag/14.0.0.3936
- [x] sonar-dummy javadoc is available here: https://javadocs.sonarsource.org/?prefix=sonar-dummy/