### PR TITLE
BUILD-5212 Revert undesired change (required only for testing)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -100,8 +100,7 @@ jobs:
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
           # During development change this to your branch name to run it in another repository
-          # ref: ${{ github.ref }}
-          ref: feat/svermeille/BUILD-5212-gh-action_release-Enhance-publish_javadoc-to-support-private-repositories
+          ref: ${{ github.ref }}
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6


### PR DESCRIPTION
Fix master branch, for testing purpose the ref has to be changed to a branch but reverted before merge. 
This issue was introduced by https://github.com/SonarSource/gh-action_release/pull/204.

We might want to have a check for that a PR time to avoid merging such changes into master in the future.