### PR TITLE
BUILD-6237 fix output when there are no artifacts to publish

### DIFF
--- a/main/release/utils/buildinfo.py
+++ b/main/release/utils/buildinfo.py
@@ -4,14 +4,17 @@ class BuildInfo:
     def __init__(self, json):
         self.json = json
 
-    def get_property(self, property_name, default=""):
+    def get_property(self, property_name, default=None):
         try:
             return self.json['buildInfo']['properties'][property_name]
-        except BaseException:
+        except KeyError:
             return default
 
-    def get_module_property(self, property_name):
-        return self.json['buildInfo']['modules'][0]['properties'][property_name]
+    def get_module_property(self, property_name, default=None):
+        try:
+            return self.json['buildInfo']['modules'][0]['properties'][property_name]
+        except KeyError:
+            return default
 
     def get_version(self):
         return self.json['buildInfo']['modules'][0]['id'].split(":")[-1]
@@ -28,14 +31,9 @@ class BuildInfo:
         return sourcerepo, targetrepo
 
     def get_artifacts_to_publish(self):
-        artifacts = None
-        try:
-            artifacts = self.get_module_property('artifactsToPublish')
-        except:
-            try:
-                artifacts = self.get_property('buildInfo.env.ARTIFACTS_TO_PUBLISH')
-            except:
-                print("no artifacts to publish")
+        artifacts = self.get_module_property('artifactsToPublish', self.get_property('buildInfo.env.ARTIFACTS_TO_PUBLISH'))
+        if not artifacts:
+            print("No artifacts to publish")
         return artifacts
 
     def is_public(self):

--- a/main/tests/utils/test_buildinfo.py
+++ b/main/tests/utils/test_buildinfo.py
@@ -1,0 +1,57 @@
+from pytest import fixture
+
+from release.utils.buildinfo import BuildInfo
+
+
+@fixture
+def build_info_with_artefacts():
+    return BuildInfo({
+        'buildInfo': {
+            'properties': {
+                'buildInfo.env.ARTIFACTS_TO_PUBLISH': 'ARTIFACTS_TO_PUBLISH'
+            },
+            'modules': [{
+                'properties': {
+                    'artifactsToPublish': 'org.sonarsource.test:test1:jar,org.sonarsource.test:test1:jar'
+                }
+            }]
+        }
+    })
+
+
+@fixture
+def build_info_with_artefacts_by_env():
+    return BuildInfo({
+        'buildInfo': {
+            'properties': {
+                'buildInfo.env.ARTIFACTS_TO_PUBLISH': 'ARTIFACTS_TO_PUBLISH'
+            }
+        }
+    })
+
+
+@fixture
+def build_info_with_no_artefacts():
+    return BuildInfo({
+        "buildInfo": {
+            'properties': {},
+            "modules": [{}]
+        }
+    })
+
+
+def test_get_artifacts_to_publish(build_info_with_artefacts):
+    artifacts = build_info_with_artefacts.get_artifacts_to_publish()
+    assert artifacts is not None
+    assert 'org.sonarsource.test:test1:jar,org.sonarsource.test:test1:jar' == artifacts
+    assert 'org.sonarsource.test' == build_info_with_artefacts.get_package()
+
+
+def test_get_artifacts_to_publish_returns_property_when_no_module_property(build_info_with_artefacts_by_env):
+    assert 'ARTIFACTS_TO_PUBLISH' == build_info_with_artefacts_by_env.get_artifacts_to_publish()
+
+
+def test_get_artifacts_to_publish_prints_message_when_no_artifacts(build_info_with_no_artefacts, capsys):
+    assert build_info_with_no_artefacts.get_artifacts_to_publish() is None
+    captured = capsys.readouterr().out.split('\n')
+    assert "No artifacts to publish" == captured[0]

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from _pytest.fixtures import fixture
+from pytest import fixture
 
 from release.utils.binaries import Binaries
 from release.utils.buildinfo import BuildInfo


### PR DESCRIPTION
"No artifacts to publish" was not printed because of get_property() defaulting to "" and not raising an exception, while get_module_property was raising an exception. Thus, the mistake in the implementation.

https://github.com/SonarSource/sonar-dummy/actions/runs/10787795372/job/29917197191 :heavy_check_mark: 
```
Promoting sonar-dummy/5208 with {'status': 'released', 'sourceRepo': 'sonarsource-private-builds', 'targetRepo': 'sonarsource-private-releases'}
publishing artifacts for sonar-dummy#5208
No artifacts to publish
```

https://github.com/SonarSource/sonar-dummy-oss/actions/runs/10788084673/job/29918093951 :heavy_check_mark: 
```
Promoting sonar-dummy-oss/5695 with {'status': 'released', 'sourceRepo': 'sonarsource-public-builds', 'targetRepo': 'sonarsource-public-releases'}
publishing artifacts for sonar-dummy-oss#5695
No artifacts to publish
```