### PR TITLE
[DO NOT MERGE] SLE-1057: Subset of signatures for Eclipse RedDeer

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -130,7 +130,7 @@ jobs:
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
           # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          ref: "task/tha/SLE-1057_Checksum"
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -15,11 +15,10 @@ COMMERCIAL_REPO = "CommercialDistribution"
 DISTRIBUTION_ID_PROD = 'E2WHX4O0Y6Z6C6'
 SONARLINT_AID = "org.sonarlint.eclipse.site"
 REDDEER_AID = "org.eclipse.reddeer.site"
+UPLOAD_CHECKSUMS = ["md5", "sha1", "sha256", "asc"]
 
 
 class Binaries:
-    upload_checksums = ["md5", "sha1", "sha256", "asc"]
-
     def __init__(self, binaries_bucket_name: str):
         self.binaries_bucket_name = binaries_bucket_name
         self.binaries_session = boto3.Session(
@@ -37,6 +36,13 @@ class Binaries:
             return COMMERCIAL_REPO
         else:
             return OSS_REPO
+    
+    @staticmethod
+    def get_actual_checksums(aid):
+        if aid == REDDEER_AID:
+            # Eclipse RedDeer does not have a signature
+            return UPLOAD_CHECKSUMS[:-1]
+        return UPLOAD_CHECKSUMS
 
     def s3_upload(self, artifact_file, filename, gid, aid, version):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
@@ -44,7 +50,7 @@ class Binaries:
 
         self.s3_client.upload_file(artifact_file, self.binaries_bucket_name, file_bucket_key)
         print(f'uploaded {artifact_file} to s3://{self.binaries_bucket_name}/{file_bucket_key}')
-        for checksum in self.upload_checksums:
+        for checksum in Binaries.get_actual_checksums(aid):
             self.s3_client.upload_file(f'{artifact_file}.{checksum}', self.binaries_bucket_name, f'{file_bucket_key}.{checksum}')
             print(f'uploaded {artifact_file}.{checksum} to s3://{self.binaries_bucket_name}/{file_bucket_key}.{checksum}')
 

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -36,7 +36,7 @@ class Binaries:
             return COMMERCIAL_REPO
         else:
             return OSS_REPO
-    
+
     @staticmethod
     def get_actual_checksums(aid):
         if aid == REDDEER_AID:

--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -4,6 +4,7 @@ from dryable import Dryable
 
 from release.steps import ReleaseRequest
 from release.utils.artifactory import Artifactory
+from release.utils.binaries import Binaries
 
 REVOKE = True
 
@@ -71,7 +72,7 @@ def publish_artifact(artifactory, binaries, artifact_to_publish, version, repo, 
     if revoke:
         binaries.s3_delete(filename, gid, s3_aid, version)
     else:
-        artifact_file = artifactory.download(artifactory_repo, gid, aid, qual, ext, version, binaries.upload_checksums)
+        artifact_file = artifactory.download(artifactory_repo, gid, aid, qual, ext, version, Binaries.get_actual_checksums(aid))
         binaries.s3_upload(artifact_file, filename, gid, s3_aid, version)
 
 

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -209,8 +209,8 @@ def test_publish_artifact_upload_file_reddeer(buildinfo_reddeer, capsys):
             patch.object(client, 'upload_file') as upload_file:
             version = buildinfo_reddeer.get_version()
             publish_artifact(artifactory, binaries, buildinfo_reddeer.get_artifacts_to_publish(), version, "repo")
-            upload_file.assert_called_with('/tmp/org.eclipse.reddeer.site-4.7.0.53.zip.asc', 'test_bucket',
-                                           'RedDeer/releases/org.eclipse.reddeer.site-4.7.0.53.zip.asc')
+            upload_file.assert_called_with('/tmp/org.eclipse.reddeer.site-4.7.0.53.zip.sha256', 'test_bucket',
+                                           'RedDeer/releases/org.eclipse.reddeer.site-4.7.0.53.zip.sha256')
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == 'publishing org.sonarsource.eclipse.reddeer:org.eclipse.reddeer.site:zip#4.7.0.53'
             assert captured[1] == 'org.sonarsource.eclipse.reddeer org.eclipse.reddeer.site zip '


### PR DESCRIPTION
As the artifact is not signed, there is `.asc` checksum available