### PR TITLE
SLE-1057: Handle Eclipse RedDeer signatures

### DIFF
--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -4,6 +4,7 @@ from dryable import Dryable
 
 from release.steps import ReleaseRequest
 from release.utils.artifactory import Artifactory
+from release.utils.binaries import Binaries
 
 REVOKE = True
 
@@ -71,7 +72,7 @@ def publish_artifact(artifactory, binaries, artifact_to_publish, version, repo, 
     if revoke:
         binaries.s3_delete(filename, gid, s3_aid, version)
     else:
-        artifact_file = artifactory.download(artifactory_repo, gid, aid, qual, ext, version, binaries.upload_checksums)
+        artifact_file = artifactory.download(artifactory_repo, gid, aid, qual, ext, version, Binaries.get_actual_checksums(aid))
         binaries.s3_upload(artifact_file, filename, gid, s3_aid, version)
 
 

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -209,8 +209,8 @@ def test_publish_artifact_upload_file_reddeer(buildinfo_reddeer, capsys):
             patch.object(client, 'upload_file') as upload_file:
             version = buildinfo_reddeer.get_version()
             publish_artifact(artifactory, binaries, buildinfo_reddeer.get_artifacts_to_publish(), version, "repo")
-            upload_file.assert_called_with('/tmp/org.eclipse.reddeer.site-4.7.0.53.zip.asc', 'test_bucket',
-                                           'RedDeer/releases/org.eclipse.reddeer.site-4.7.0.53.zip.asc')
+            upload_file.assert_called_with('/tmp/org.eclipse.reddeer.site-4.7.0.53.zip.sha256', 'test_bucket',
+                                           'RedDeer/releases/org.eclipse.reddeer.site-4.7.0.53.zip.sha256')
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == 'publishing org.sonarsource.eclipse.reddeer:org.eclipse.reddeer.site:zip#4.7.0.53'
             assert captured[1] == 'org.sonarsource.eclipse.reddeer org.eclipse.reddeer.site zip '


### PR DESCRIPTION
Eclipse RedDeer is not signed and therefore does not offer a `.asc` signature. This must be taken into account when downloading from Artifactory for the following upload to SonarSource Binaries.

This was tested in #310 alongside the [Eclipse RedDeer release](https://binaries.sonarsource.com/?prefix=RedDeer/releases/4.7.1.81/) and on SonarQube for Eclipse by [incorporating this released artifact](https://github.com/SonarSource/sonarlint-eclipse/pull/839).