### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/it-test-download-build.yml
+++ b/.github/workflows/it-test-download-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   it-tests-default-values:
     name: IT Test - use default inputs values should generate expected output"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write
       contents: write
@@ -36,7 +36,7 @@ jobs:
 
   it-tests-use-flat-download-true:
     name: IT Test - use flat-download=true should generate expected output"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write
       contents: write
@@ -64,7 +64,7 @@ jobs:
 
   it-tests:
       name: "All IT Tests have to pass (download-build)"
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04-large
       if: always()
       needs:
         # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   release:
     name: Test action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Necessary to access local action)
       - uses: ./main

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -31,7 +31,7 @@ name: Javadoc publication
 jobs:
   javadoc-publication:
     name: Publish javadoc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write  # to authenticate via OIDC
       contents: read  # to revert a github release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -100,7 +100,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write  # to authenticate via OIDC
       contents: write  # to revert a github release
@@ -318,7 +318,7 @@ jobs:
 
   datadog:
     name: Push results to datadog
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     needs:
       - release
       - mavenCentral

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -23,7 +23,7 @@ name: Maven Central
 jobs:
   maven-central:
     name: Push to maven Central
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write  # to authenticate via OIDC
       contents: read  # to revert a github release

--- a/.github/workflows/npmjs.yaml
+++ b/.github/workflows/npmjs.yaml
@@ -36,7 +36,7 @@ name: NpmJS
 jobs:
   publish-to-npm:
     name: Publish to npmjs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     steps:
       - uses: SonarSource/gh-action_pre-commit@3d5b503c1ce51d0f92665875b9bea716eff1e70f # 1.0.7
         with:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -36,7 +36,7 @@ name: PyPI
 jobs:
   pypi:
     name: Publish to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write  # to authenticate via OIDC
       contents: read  # to revert a GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release ${{ inputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/update-v-branch.yml
+++ b/.github/workflows/update-v-branch.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-v-branch:
     name: Update v* branch to ${{ inputs.tag }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-large
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.


[BUILD-8073]: https://sonarsource.atlassian.net/browse/BUILD-8073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ