### PR TITLE
BUILD-7998 Update CODEOWNERS and update action ref

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
+# Default owners for everything in the repo
 * @sonarsource/platform-eng-xp-squad
 
-# No review needed for documentation changes
-*.md
+# Protect the CODEOWNERS file itself
+.github/CODEOWNERS @sonarsource/platform-eng-xp-squad

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,6 @@ jobs:
           python -m pip install --upgrade requests
           python main_test.py
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@master  # First-party SonarSource action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: List javadoc files
         run: ls "${{ steps.local_repo.outputs.dir }}/javadoc/${{ github.event.release.tag_name }}"
       - name: Publish javadoc files to S3
-        uses: SonarSource/gh-action_release/aws-s3@master
+        uses: ./aws-s3
         with:
           command: cp
           flags: --recursive
@@ -103,7 +103,7 @@ jobs:
           aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
           aws_region: eu-central-1
       - name: Delete dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@master
+        uses: ./aws-s3
         with:
           command: rm
           source: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory || github.event.repository.name }}/latest
@@ -113,7 +113,7 @@ jobs:
           aws_region: eu-central-1
         continue-on-error: true # the first time a project publish javadoc, there is no latest dir available
       - name: Upload to dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@master
+        uses: ./aws-s3
         with:
           command: cp
           flags: --recursive

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -57,15 +57,15 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@master
+        uses: ./download-build  # Local action
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
           exclusions: ${{ inputs.downloadExclusions }}
-      - name: Maven Central Sync
+      - name: Sync to Maven Central
+        uses: ./maven-central-sync  # Local action
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@master
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
           central-url: https://central.sonatype.com


### PR DESCRIPTION
This pull request includes updates to the repository's configuration files to improve maintainability and streamline workflows. The most notable changes involve replacing external GitHub actions with local actions and refining ownership rules for the repository.

### Repository Ownership Updates:
* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R5): Added default owners for the entire repository and protected the `CODEOWNERS` file by assigning ownership to the `@sonarsource/platform-eng-xp-squad` team. Removed the rule that excluded `.md` files from review.

### Workflow Enhancements:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L47-R47): Added a comment to clarify the use of the SonarSource GitHub action for SonarCloud scans.

* [`.github/workflows/javadoc-publication.yaml`](diffhunk://#diff-62a5148518264050fa5df87ae767919a004f44db79589d997d9f3abba92e2ad6L95-R95): Replaced the external `SonarSource/gh-action_release/aws-s3` action with a local `./aws-s3` action for publishing, deleting, and uploading javadoc files to S3. This change ensures better control over the actions used in the workflow. [[1]](diffhunk://#diff-62a5148518264050fa5df87ae767919a004f44db79589d997d9f3abba92e2ad6L95-R95) [[2]](diffhunk://#diff-62a5148518264050fa5df87ae767919a004f44db79589d997d9f3abba92e2ad6L106-R106) [[3]](diffhunk://#diff-62a5148518264050fa5df87ae767919a004f44db79589d997d9f3abba92e2ad6L116-R116)

* [`.github/workflows/maven-central.yaml`](diffhunk://#diff-d3b857e1c9a6e0e0c3fe58de29be1f4039372d28fd4d39b24aef6c473473dfd7L60-L68): Replaced the external `SonarSource/gh-action_release/download-build` and `SonarSource/gh-action_release/maven-central-sync` actions with local actions (`./download-build` and `./maven-central-sync`). Updated step names for clarity and added comments to indicate the use of local actions.