### PR TITLE
BUILD-10273 Fix Artifactory authentication for download redirects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip pipenv
           make test
-          sed -i "s|<source>${GITHUB_WORKSPACE}|<source>/github/workspace|g" "${GITHUB_WORKSPACE}/main/build/coverage.xml"
+          sed -i "s|<source>release</source>|<source>main/release</source>|g" "build/coverage.xml"
       - name: Test
         working-directory: datadog-ingest
         run: |

--- a/main/.coveragerc
+++ b/main/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+relative_files = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+    # Don't complain about missing debug-only code:
+    def __repr__
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+[xml]
+output = build/coverage.xml
+
+[html]
+directory = build/coverage-html


### PR DESCRIPTION
This pull request refactors the Artifactory download utility to use the `requests` library instead of `urllib`, modernizes and improves test coverage for the new download logic, and adds coverage configuration for better reporting. This fixes the HTTP 400 errors due to Artifactory redirection.

Tested with https://github.com/SonarSource/sonar-enterprise/actions/runs/21400897672/job/61611336030