### PR TITLE
Fix get_artifacts_to_publish to collect artifacts from all modules

### DIFF
--- a/main/release/utils/buildinfo.py
+++ b/main/release/utils/buildinfo.py
@@ -31,7 +31,12 @@ class BuildInfo:
         return sourcerepo, targetrepo
 
     def get_artifacts_to_publish(self):
-        artifacts = self.get_module_property('artifactsToPublish', self.get_property('buildInfo.env.ARTIFACTS_TO_PUBLISH'))
+        modules = self.json.get('buildInfo', {}).get('modules', [])
+        combined = ','.join(m.get('properties', {}).get('artifactsToPublish', '') for m in modules)
+        all_artifacts = list(dict.fromkeys(a for a in combined.split(',') if a))
+        if all_artifacts:
+            return ','.join(all_artifacts)
+        artifacts = self.get_property('buildInfo.env.ARTIFACTS_TO_PUBLISH')
         if not artifacts:
             print("No artifacts to publish")
         return artifacts

--- a/main/tests/utils/test_buildinfo.py
+++ b/main/tests/utils/test_buildinfo.py
@@ -12,7 +12,7 @@ def build_info_with_artefacts():
             },
             'modules': [{
                 'properties': {
-                    'artifactsToPublish': 'org.sonarsource.test:test1:jar,org.sonarsource.test:test1:jar'
+                    'artifactsToPublish': 'org.sonarsource.test:test1:jar,org.sonarsource.test:test2:jar'
                 }
             }]
         }
@@ -43,7 +43,7 @@ def build_info_with_no_artefacts():
 def test_get_artifacts_to_publish(build_info_with_artefacts):
     artifacts = build_info_with_artefacts.get_artifacts_to_publish()
     assert artifacts is not None
-    assert 'org.sonarsource.test:test1:jar,org.sonarsource.test:test1:jar' == artifacts
+    assert 'org.sonarsource.test:test1:jar,org.sonarsource.test:test2:jar' == artifacts
     assert 'org.sonarsource.test' == build_info_with_artefacts.get_package()
 
 
@@ -55,3 +55,42 @@ def test_get_artifacts_to_publish_prints_message_when_no_artifacts(build_info_wi
     assert build_info_with_no_artefacts.get_artifacts_to_publish() is None
     captured = capsys.readouterr().out.split('\n')
     assert "No artifacts to publish" == captured[0]
+
+
+@fixture
+def build_info_with_artefacts_across_modules():
+    return BuildInfo({
+        'buildInfo': {
+            'properties': {
+                'buildInfo.env.ARTIFACTS_TO_PUBLISH': 'ARTIFACTS_TO_PUBLISH'
+            },
+            'modules': [
+                {
+                    'properties': {
+                        'artifactsToPublish': 'org.sonarsource.dotnet:sonar-csharp-plugin:jar,org.sonarsource.dotnet:sonar-vbnet-plugin:jar'
+                    }
+                },
+                {
+                    'properties': {
+                        'artifactsToPublish': 'org.sonarsource.dotnet:sonar-csharp-plugin:jar,org.sonarsource.dotnet:sonar-vbnet-plugin:jar,com.sonarsource.dotnet:sonar-csharp-enterprise-plugin:jar,com.sonarsource.dotnet:sonar-vbnet-enterprise-plugin:jar'
+                    }
+                }
+            ]
+        }
+    })
+
+
+def test_get_artifacts_to_publish_merges_all_modules(build_info_with_artefacts_across_modules):
+    artifacts = build_info_with_artefacts_across_modules.get_artifacts_to_publish()
+    artifact_list = artifacts.split(',')
+    assert len(artifact_list) == 4
+    assert 'org.sonarsource.dotnet:sonar-csharp-plugin:jar' in artifact_list
+    assert 'org.sonarsource.dotnet:sonar-vbnet-plugin:jar' in artifact_list
+    assert 'com.sonarsource.dotnet:sonar-csharp-enterprise-plugin:jar' in artifact_list
+    assert 'com.sonarsource.dotnet:sonar-vbnet-enterprise-plugin:jar' in artifact_list
+
+
+def test_get_artifacts_to_publish_deduplicates_across_modules(build_info_with_artefacts_across_modules):
+    artifacts = build_info_with_artefacts_across_modules.get_artifacts_to_publish()
+    artifact_list = artifacts.split(',')
+    assert len(artifact_list) == len(set(artifact_list))


### PR DESCRIPTION
## Summary

- `get_artifacts_to_publish()` previously read `artifactsToPublish` only from `modules[0]` of the Artifactory build info JSON
- In `sonar-dotnet-enterprise`, Maven's reactor places the public module first, so the enterprise root pom (which lists the enterprise JARs) was never read — causing enterprise JARs to never be published to `CommercialDistribution`
- Now all modules are iterated with order-preserving deduplication (first occurrence wins), so artifacts from any module are included

## Test plan

- [ ] All existing tests pass
- [ ] `test_get_artifacts_to_publish_merges_all_modules` — verifies all 4 artifacts (2 public + 2 enterprise) are collected across two modules
- [ ] `test_get_artifacts_to_publish_deduplicates_across_modules` — verifies duplicates inherited across modules are collapsed to a single entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)