### PR TITLE
BUILD-10382 Use github.workflow_sha for cross-repo checkout

### DIFF
--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -31,6 +31,11 @@ name: Javadoc publication
         type: boolean
         description: Indicate if the project is generating a public release or not
         required: true
+      ghActionReleaseRef:
+        type: string
+        description: Override ref for gh-action_release checkout. Set to a branch name when testing from a consumer repository.
+        default: ''
+        required: false
 
 jobs:
   javadoc-publication:
@@ -48,7 +53,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: SonarSource/gh-action_release
-          ref: ${{ github.ref }}
+          # For cross-repo testing, pass ghActionReleaseRef input with the branch name
+          ref: ${{ inputs.ghActionReleaseRef || github.ref }}
           path: gh-action_release
       - name: Get the version
         id: get_version

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -48,8 +48,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: SonarSource/gh-action_release
-          # github.workflow_sha resolves to the commit SHA of the reusable workflow
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ github.ref }}
           path: gh-action_release
       - name: Get the version
         id: get_version

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -48,7 +48,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: SonarSource/gh-action_release
-          ref: ${{ github.ref }}
+          # github.workflow_sha resolves to the commit SHA of the reusable workflow
+          ref: ${{ github.workflow_sha }}
           path: gh-action_release
       - name: Get the version
         id: get_version

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -134,10 +134,9 @@ jobs:
           # Hardcode the repository name, because GitHub Actions does not provide a built-in context or variable
           # to directly reference the repository where the reusable workflow is defined
           repository: SonarSource/gh-action_release
-          # github.workflow_sha resolves to the commit SHA of the reusable workflow,
-          # ensuring the correct version of gh-action_release is checked out regardless
-          # of whether this is called locally or from a consumer repository
-          ref: ${{ github.workflow_sha }}
+          # This property is changed during the release process to reference the correct tag
+          # During development change this to your branch name to run it in another repository
+          ref: ${{ github.ref }}
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -347,10 +346,9 @@ jobs:
           # Hardcode the repository name, because GitHub Actions does not provide a built-in context or variable
           # to directly reference the repository where the reusable workflow is defined
           repository: SonarSource/gh-action_release
-          # github.workflow_sha resolves to the commit SHA of the reusable workflow,
-          # ensuring the correct version of gh-action_release is checked out regardless
-          # of whether this is called locally or from a consumer repository
-          ref: ${{ github.workflow_sha }}
+          # This property is changed during the release process to reference the correct tag
+          # During development change this to your branch name to run it in another repository
+          ref: ${{ github.ref }}
           path: gh-action_release
 
       - name: Vault

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -134,9 +134,10 @@ jobs:
           # Hardcode the repository name, because GitHub Actions does not provide a built-in context or variable
           # to directly reference the repository where the reusable workflow is defined
           repository: SonarSource/gh-action_release
-          # This property is changed during the release process to reference the correct tag
-          # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          # github.workflow_sha resolves to the commit SHA of the reusable workflow,
+          # ensuring the correct version of gh-action_release is checked out regardless
+          # of whether this is called locally or from a consumer repository
+          ref: ${{ github.workflow_sha }}
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -346,9 +347,10 @@ jobs:
           # Hardcode the repository name, because GitHub Actions does not provide a built-in context or variable
           # to directly reference the repository where the reusable workflow is defined
           repository: SonarSource/gh-action_release
-          # This property is changed during the release process to reference the correct tag
-          # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          # github.workflow_sha resolves to the commit SHA of the reusable workflow,
+          # ensuring the correct version of gh-action_release is checked out regardless
+          # of whether this is called locally or from a consumer repository
+          ref: ${{ github.workflow_sha }}
           path: gh-action_release
 
       - name: Vault

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,6 +102,11 @@ on:
         description: Indicate whether this is a dummy project.
         default: false
         required: false
+      ghActionReleaseRef:
+        type: string
+        description: Override ref for gh-action_release checkout. Set to a branch name when testing from a consumer repository.
+        default: ''
+        required: false
 
 jobs:
   release:
@@ -135,8 +140,8 @@ jobs:
           # to directly reference the repository where the reusable workflow is defined
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
-          # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          # For cross-repo testing, pass ghActionReleaseRef input with the branch name
+          ref: ${{ inputs.ghActionReleaseRef || github.ref }}
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -291,6 +296,7 @@ jobs:
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       javadocDestinationDirectory: ${{ inputs.javadocDestinationDirectory }}
       publicRelease: ${{ inputs.publicRelease }}
+      ghActionReleaseRef: ${{ inputs.ghActionReleaseRef }}
 
   testPypi:
     name: TestPyPI
@@ -347,8 +353,8 @@ jobs:
           # to directly reference the repository where the reusable workflow is defined
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
-          # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          # For cross-repo testing, pass ghActionReleaseRef input with the branch name
+          ref: ${{ inputs.ghActionReleaseRef || github.ref }}
           path: gh-action_release
 
       - name: Vault

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ __pycache__
 build/
 out/
 coverage.xml
-docs/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 build/
 out/
 coverage.xml
+docs/plans/

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ ie: [`5.0.0`](https://github.com/SonarSource/gh-action_release/releases/tag/5.0.
 
 Branches prefixed with a `v` are pointers to the last major versions, ie: [`v6`](https://github.com/SonarSource/gh-action_release/tree/v6).
 
-> Note: Development branches (including `master`) can be referenced from consumer repositories for testing purposes.
-> For production use, always reference a `v` branch or a specific tag.
+> Note: the `master` branch is used for development and can not be referenced directly. Use a `v` branch or a tag instead.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ ie: [`5.0.0`](https://github.com/SonarSource/gh-action_release/releases/tag/5.0.
 
 Branches prefixed with a `v` are pointers to the last major versions, ie: [`v6`](https://github.com/SonarSource/gh-action_release/tree/v6).
 
-> Note: the `master` branch is used for development and can not be referenced directly. Use a `v` branch or a tag instead.
+> Note: Development branches (including `master`) can be referenced from consumer repositories for testing purposes
+> by passing the `ghActionReleaseRef` input with the branch name.
+> For production use, always reference a `v` branch or a specific tag.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ ie: [`5.0.0`](https://github.com/SonarSource/gh-action_release/releases/tag/5.0.
 
 Branches prefixed with a `v` are pointers to the last major versions, ie: [`v6`](https://github.com/SonarSource/gh-action_release/tree/v6).
 
-> Note: the `master` branch is used for development and can not be referenced directly. Use a `v` branch or a tag instead.
+> Note: Development branches (including `master`) can be referenced from consumer repositories for testing purposes.
+> For production use, always reference a `v` branch or a specific tag.
 
 ## Development
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@ git checkout "${branch}"
 git pull origin "${branch}"
 original_ref=$(git rev-parse HEAD)
 git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${branch},\1${version},g"
-git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s/ref: \${{ github.ref }}/ref: ${version}/g"
+git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s/ref: \${{ inputs.ghActionReleaseRef || github.ref }}/ref: ${version}/g"
 git commit -m "chore: prepare ${version} for future reference" -a
 next_ref=$(git show -s --pretty=format:'%H')
 git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${version},\1${next_ref},g"


### PR DESCRIPTION
## Summary

- Add optional `ghActionReleaseRef` input to the release reusable workflow
- When set, overrides `github.ref` for the gh-action_release checkout, allowing consumer repos to test a specific branch
- When not set, falls back to `github.ref` (existing behavior, unchanged)
- Update `release.sh` sed pattern to match the new ref expression

## Problem

When a consumer repo (e.g., sonar-dummy-maven-enterprise) calls `main.yaml@feat/some-branch`, the checkout step `ref: ${{ github.ref }}` fails because `github.ref` resolves to the **caller's** ref (e.g., `refs/tags/10.8.0`), which doesn't exist in gh-action_release.

`github.workflow_sha` was tried first but it also resolves to the caller's context, not the reusable workflow's.

## Solution

Add a `ghActionReleaseRef` input that consumers pass when testing a branch:

```yaml
uses: SonarSource/gh-action_release/.github/workflows/main.yaml@feat/some-branch
with:
  ghActionReleaseRef: feat/some-branch
```

The checkout becomes: `ref: ${{ inputs.ghActionReleaseRef || github.ref }}`

## Files changed

| File | Change |
|---|---|
| `.github/workflows/main.yaml` | Add `ghActionReleaseRef` input, update 2 checkout refs, pass through to javadoc workflow |
| `.github/workflows/javadoc-publication.yaml` | Add `ghActionReleaseRef` input, update 1 checkout ref |
| `scripts/release.sh` | Update sed pattern to match new ref expression |
| `README.md` | Update note about branch referencing |

## Test plan

- [ ] IT tests pass on this PR (automated via `it-test.yml`)
- [ ] Cross-repo test: consumer repo references this branch with `ghActionReleaseRef` input