### PR TITLE
PREQ-4535: Use hierarchical S3 path (version/platform) for binaries with platform qualifier

### DIFF
--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -17,6 +17,26 @@ SONARLINT_AID = "org.sonarlint.eclipse.site"
 REDDEER_AID = "org.eclipse.reddeer.site"
 UPLOAD_CHECKSUMS = ["md5", "sha1", "sha256", "asc"]
 
+# Map artifact qualifier (e.g. linux-x64, darwin-arm64) to folder name for hierarchical S3 structure.
+# Used to produce binaries.sonarsource.com layout: product/version/platform/file
+QUAL_TO_PLATFORM_FOLDER = {
+    "linux": "linux",
+    "linux-x64": "linux",
+    "linux-arm64": "linux",
+    "linux-arm": "linux",
+    "darwin": "mac",
+    "darwin-x64": "mac",
+    "darwin-arm64": "mac",
+    "mac": "mac",
+    "mac-x64": "mac",
+    "macos-x64": "mac",
+    "win32": "windows",
+    "win32-x64": "windows",
+    "win32-arm64": "windows",
+    "windows": "windows",
+    "windows-x64": "windows",
+}
+
 
 class Binaries:
     def __init__(self, binaries_bucket_name: str):
@@ -44,9 +64,24 @@ class Binaries:
             return UPLOAD_CHECKSUMS[:-1]
         return UPLOAD_CHECKSUMS
 
-    def s3_upload(self, artifact_file, filename, gid, aid, version):
+    @staticmethod
+    def qual_to_platform_folder(qual):
+        """Map artifact qualifier to platform folder for hierarchical S3 structure."""
+        if not qual:
+            return None
+        folder = QUAL_TO_PLATFORM_FOLDER.get(qual.lower())
+        if folder:
+            return folder
+        # Fallback: use first segment before hyphen (e.g. linux-x64 -> linux)
+        return qual.split("-")[0].lower() if "-" in qual else qual.lower()
+
+    def s3_upload(self, artifact_file, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        file_bucket_key = f"{root_bucket_key}/{filename}"
+        platform_folder = self.qual_to_platform_folder(qual) if qual else None
+        if platform_folder:
+            file_bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
+        else:
+            file_bucket_key = f"{root_bucket_key}/{filename}"
 
         self.s3_client.upload_file(artifact_file, self.binaries_bucket_name, file_bucket_key)
         print(f'uploaded {artifact_file} to s3://{self.binaries_bucket_name}/{file_bucket_key}')
@@ -130,9 +165,13 @@ class Binaries:
         invalidation_uri = response['Location']
         print(f'CloudFront invalidation: {invalidation_uri}')
 
-    def s3_delete(self, filename, gid, aid, version):
+    def s3_delete(self, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        bucket_key = f"{root_bucket_key}/{filename}"
+        platform_folder = self.qual_to_platform_folder(qual) if qual else None
+        if platform_folder:
+            bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
+        else:
+            bucket_key = f"{root_bucket_key}/{filename}"
 
         self.s3_client.delete_object(Bucket=self.binaries_bucket_name, Key=bucket_key)
         print(f'deleted {bucket_key}')

--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -70,10 +70,10 @@ def publish_artifact(artifactory, binaries, artifact_to_publish, version, repo, 
         s3_aid = aid
 
     if revoke:
-        binaries.s3_delete(filename, gid, s3_aid, version)
+        binaries.s3_delete(filename, gid, s3_aid, version, qual)
     else:
         artifact_file = artifactory.download(artifactory_repo, gid, aid, qual, ext, version, Binaries.get_actual_checksums(aid))
-        binaries.s3_upload(artifact_file, filename, gid, s3_aid, version)
+        binaries.s3_upload(artifact_file, filename, gid, s3_aid, version, qual)
 
 
 def set_output(output_name, value):

--- a/main/tests/binaries_test.py
+++ b/main/tests/binaries_test.py
@@ -60,6 +60,15 @@ def test_s3_delete_sonarlint_eclipse():
     bucket.objects.filter.return_value.delete.assert_called_once()
 
 
+def test_qual_to_platform_folder():
+    assert Binaries.qual_to_platform_folder(None) is None
+    assert Binaries.qual_to_platform_folder('') is None
+    assert Binaries.qual_to_platform_folder('linux-x64') == 'linux'
+    assert Binaries.qual_to_platform_folder('darwin-arm64') == 'mac'
+    assert Binaries.qual_to_platform_folder('win32-x64') == 'windows'
+    assert Binaries.qual_to_platform_folder('unknown-platform') == 'unknown'
+
+
 @pytest.mark.parametrize(
     'group_id, root_bucket_key',
     [

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -86,7 +86,7 @@ def test_publish_artifact_s3_upload(buildinfo_com, buildinfo_org, capsys):
             # com
             publish_artifact(artifactory, binaries, buildinfo_com.get_artifacts_to_publish(), version, "repo")
             s3_upload.assert_called_once_with("/tmp/dummy-1.0.2.456.jar", "dummy-1.0.2.456.jar", "com.sonarsource.dummy", "dummy",
-                                              "1.0.2.456")
+                                              "1.0.2.456", "")
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == "publishing com.sonarsource.dummy:dummy:jar#1.0.2.456"
             assert captured[1] == "com.sonarsource.dummy dummy jar "
@@ -94,7 +94,7 @@ def test_publish_artifact_s3_upload(buildinfo_com, buildinfo_org, capsys):
             # org
             publish_artifact(artifactory, binaries, buildinfo_org.get_artifacts_to_publish(), version, "repo")
             s3_upload.assert_called_with("/tmp/dummy-1.0.2.456.jar", "dummy-1.0.2.456-qualifier.jar", "org.sonarsource.dummy", "dummy",
-                                         "1.0.2.456")
+                                         "1.0.2.456", "qualifier")
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == "publishing org.sonarsource.dummy:dummy:jar:qualifier#1.0.2.456"
             assert captured[1] == "org.sonarsource.dummy dummy jar qualifier"
@@ -109,7 +109,7 @@ def test_publish_artifact_s3_upload_sonarqube(buildinfo_sonarqube, capsys):
         with patch('release.utils.binaries.Binaries.s3_upload') as s3_upload:
             publish_artifact(artifactory, binaries, buildinfo_sonarqube.get_artifacts_to_publish(), version, "repo")
             s3_upload.assert_called_once_with("/tmp/sonarqube-10.0.0.66185.zip", "sonarqube-10.0.0.66185.zip", 'org.sonarsource.sonarqube',
-                                              'sonarqube', '10.0.0.66185')
+                                              'sonarqube', '10.0.0.66185', '')
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == "publishing org.sonarsource.sonarqube:sonar-application:zip#10.0.0.66185"
             assert captured[1] == "org.sonarsource.sonarqube sonar-application zip "
@@ -144,23 +144,23 @@ def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
                    's3://test_bucket/CommercialDistribution/dummy/dummy-1.0.2.456.jar.asc'
             mock_upload_eclipse_update_site_unzip.assert_not_called()
             mock_upload_sonarlint_p2_site.assert_not_called()
-            # org
+            # org (with qualifier: hierarchical path version/platform/filename)
             version = buildinfo_org.get_version()
             publish_artifact(artifactory, binaries, buildinfo_org.get_artifacts_to_publish(), version, "repo")
             upload_file.assert_called_with('/tmp/dummy-1.0.2.456.jar.asc', 'test_bucket',
-                                           'Distribution/dummy/dummy-1.0.2.456-qualifier.jar.asc')
+                                           'Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.asc')
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == 'publishing org.sonarsource.dummy:dummy:jar:qualifier#1.0.2.456'
             assert captured[1] == 'org.sonarsource.dummy dummy jar qualifier'
-            assert captured[2] == 'uploaded /tmp/dummy-1.0.2.456.jar to s3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar'
+            assert captured[2] == 'uploaded /tmp/dummy-1.0.2.456.jar to s3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar'
             assert captured[3] == 'uploaded /tmp/dummy-1.0.2.456.jar.md5 to ' \
-                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.md5'
+                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.md5'
             assert captured[4] == 'uploaded /tmp/dummy-1.0.2.456.jar.sha1 to ' \
-                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.sha1'
+                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.sha1'
             assert captured[5] == 'uploaded /tmp/dummy-1.0.2.456.jar.sha256 to ' \
-                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.sha256'
+                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.sha256'
             assert captured[6] == 'uploaded /tmp/dummy-1.0.2.456.jar.asc to ' \
-                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.asc'
+                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.asc'
             mock_upload_eclipse_update_site_unzip.assert_not_called()
             mock_upload_sonarlint_p2_site.assert_not_called()
 
@@ -226,4 +226,4 @@ def test_revoke_publish_artifact():
     binaries = MagicMock()
     publish_artifact(artifactory, binaries, "groupId:artefactId:ext", "version", "repo", True)
     artifactory.assert_not_called()
-    binaries.s3_delete.assert_called_once_with('artefactId-version.ext', 'groupId', 'artefactId', 'version')
+    binaries.s3_delete.assert_called_once_with('artefactId-version.ext', 'groupId', 'artefactId', 'version', '')


### PR DESCRIPTION
## Summary

- **Root cause**: Artifacts with platform qualifiers (e.g. `linux-x64`, `darwin-arm64`, `win32-x64`) were uploaded to binaries.sonarsource.com with a flat structure: `product/filename`. The S3 bucket listing (used by the CDN) showed a "massive flat list" instead of a navigable hierarchy.
- **Solution**: When an artifact has a platform qualifier, upload to `product/version/platform/filename`. This produces the desired structure:
  ```
  sonar-cli/
    0.1/
      linux/
      mac/
      windows/
    0.2/
  ```
- **Backward compatibility**: Artifacts without qualifier keep the existing flat structure (`product/filename`).
- **Platform mapping**: Added `QUAL_TO_PLATFORM_FOLDER` to map qualifiers (linux-x64, darwin-arm64, win32-x64, etc.) to folder names (linux, mac, windows). Unknown qualifiers fall back to the first segment before the hyphen.

## JIRA

https://sonarsource.atlassian.net/browse/PREQ-4535

## Test plan

- [x] All existing unit tests pass (`binaries_test.py`)
- [x] Added `test_qual_to_platform_folder` for the new mapping logic
- [ ] Manual: Release sonar-cli (or another project with platform-specific artifacts) and verify the folder structure on https://binaries.sonarsource.com