### PR TITLE
PREQ-4535 scope hierarchical binaries layout to sonarqube-cli

### DIFF
--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -17,8 +17,12 @@ SONARLINT_AID = "org.sonarlint.eclipse.site"
 REDDEER_AID = "org.eclipse.reddeer.site"
 UPLOAD_CHECKSUMS = ["md5", "sha1", "sha256", "asc"]
 
-# Map artifact qualifier (e.g. linux-x64, darwin-arm64) to folder name for hierarchical S3 structure.
-# Used to produce binaries.sonarsource.com layout: product/version/platform/file
+# Hierarchical S3 layout (product/version/platform/file) for qualified artifacts is limited to
+# sonarqube-cli only (PREQ-4535). All other artifact IDs keep the legacy flat path.
+SONARQUBE_CLI_AID = "sonarqube-cli"
+
+# Map artifact qualifier (e.g. linux-x64, darwin-arm64) to folder name for hierarchical S3 structure
+# (used only when aid == SONARQUBE_CLI_AID and qual is set).
 QUAL_TO_PLATFORM_FOLDER = {
     "linux": "linux",
     "linux-x64": "linux",
@@ -75,9 +79,22 @@ class Binaries:
         # Fallback: use first segment before hyphen (e.g. linux-x64 -> linux)
         return qual.split("-")[0].lower() if "-" in qual else qual.lower()
 
+    @staticmethod
+    def use_hierarchical_qualifier_layout(aid, qual):
+        return bool(qual) and aid == SONARQUBE_CLI_AID
+
+    def get_flat_bucket_key(self, root_bucket_key, filename):
+        return f"{root_bucket_key}/{filename}"
+
+    def get_hierarchical_bucket_key(self, root_bucket_key, filename, version, qual):
+        platform_folder = self.qual_to_platform_folder(qual)
+        return f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
+
     def s3_upload(self, artifact_file, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        platform_folder = self.qual_to_platform_folder(qual) if qual else None
+        platform_folder = None
+        if Binaries.use_hierarchical_qualifier_layout(aid, qual):
+            platform_folder = self.qual_to_platform_folder(qual)
         if platform_folder:
             file_bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
         else:
@@ -167,14 +184,17 @@ class Binaries:
 
     def s3_delete(self, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        platform_folder = self.qual_to_platform_folder(qual) if qual else None
-        if platform_folder:
-            bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
-        else:
-            bucket_key = f"{root_bucket_key}/{filename}"
+        bucket_keys = [self.get_flat_bucket_key(root_bucket_key, filename)]
+        if Binaries.use_hierarchical_qualifier_layout(aid, qual):
+            bucket_keys = [self.get_hierarchical_bucket_key(root_bucket_key, filename, version, qual)]
+        elif qual:
+            # Backward compatibility for artifacts published by v6.4.0, where all qualifiers
+            # used the hierarchical version/platform layout.
+            bucket_keys.append(self.get_hierarchical_bucket_key(root_bucket_key, filename, version, qual))
 
-        self.s3_client.delete_object(Bucket=self.binaries_bucket_name, Key=bucket_key)
-        print(f'deleted {bucket_key}')
+        for bucket_key in dict.fromkeys(bucket_keys):
+            self.s3_client.delete_object(Bucket=self.binaries_bucket_name, Key=bucket_key)
+            print(f'deleted {bucket_key}')
 
         if aid == SONARLINT_AID:
             version_bucket_key = f"{root_bucket_key}/{version}/"

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -92,13 +92,10 @@ class Binaries:
 
     def s3_upload(self, artifact_file, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        platform_folder = None
         if Binaries.use_hierarchical_qualifier_layout(aid, qual):
-            platform_folder = self.qual_to_platform_folder(qual)
-        if platform_folder:
-            file_bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
+            file_bucket_key = self.get_hierarchical_bucket_key(root_bucket_key, filename, version, qual)
         else:
-            file_bucket_key = f"{root_bucket_key}/{filename}"
+            file_bucket_key = self.get_flat_bucket_key(root_bucket_key, filename)
 
         self.s3_client.upload_file(artifact_file, self.binaries_bucket_name, file_bucket_key)
         print(f'uploaded {artifact_file} to s3://{self.binaries_bucket_name}/{file_bucket_key}')

--- a/main/tests/binaries_test.py
+++ b/main/tests/binaries_test.py
@@ -69,6 +69,13 @@ def test_qual_to_platform_folder():
     assert Binaries.qual_to_platform_folder('unknown-platform') == 'unknown'
 
 
+def test_use_hierarchical_qualifier_layout():
+    assert Binaries.use_hierarchical_qualifier_layout('sonarqube-cli', 'linux-x64') is True
+    assert Binaries.use_hierarchical_qualifier_layout('sonarqube-cli', '') is False
+    assert Binaries.use_hierarchical_qualifier_layout('sonar-scanner-cli', 'linux-x64') is False
+    assert Binaries.use_hierarchical_qualifier_layout('dummy', 'cyclonedx') is False
+
+
 @pytest.mark.parametrize(
     'group_id, root_bucket_key',
     [
@@ -83,3 +90,28 @@ def test_s3_delete_common_case(group_id, root_bucket_key):
     with patch('boto3.Session', return_value=binaries_session):
         Binaries('bucket').s3_delete('filename', group_id, "aid", 'version')
     client.delete_object.assert_called_once_with(Bucket='bucket', Key=f'{root_bucket_key}/aid/filename')
+
+
+def test_s3_delete_sonarqube_cli_qualified():
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
+        Binaries('bucket').s3_delete(
+            'sonarqube-cli-1.0.0-linux-x64.zip', 'org.sonarsource.sonarqube', 'sonarqube-cli', '1.0.0', 'linux-x64')
+    client.delete_object.assert_called_once_with(
+        Bucket='bucket', Key='Distribution/sonarqube-cli/1.0.0/linux/sonarqube-cli-1.0.0-linux-x64.zip')
+
+
+def test_s3_delete_non_cli_qualified_deletes_flat_and_legacy_hierarchical():
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
+        Binaries('bucket').s3_delete(
+            'other-1.0.0-linux-x64.zip', 'org.sonarsource.foo', 'other', '1.0.0', 'linux-x64')
+    client.delete_object.assert_has_calls([
+        call(Bucket='bucket', Key='Distribution/other/other-1.0.0-linux-x64.zip'),
+        call(Bucket='bucket', Key='Distribution/other/1.0.0/linux/other-1.0.0-linux-x64.zip')
+    ])
+    assert client.delete_object.call_count == 2

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -76,6 +76,20 @@ def buildinfo_sonarqube():
     })
 
 
+@fixture
+def buildinfo_sonarqube_cli():
+    return BuildInfo({
+        "buildInfo": {
+            "modules": [{
+                "properties": {
+                    "artifactsToPublish": "org.sonarsource.sonarqube:sonarqube-cli:zip:linux-x64",
+                },
+                "id": "org.sonarsource.sonarqube:sonarqube-cli:0.6.0.500",
+            }]
+        }
+    })
+
+
 def test_publish_artifact_s3_upload(buildinfo_com, buildinfo_org, capsys):
     client = MagicMock()
     with patch('boto3.client', return_value=client):
@@ -115,6 +129,29 @@ def test_publish_artifact_s3_upload_sonarqube(buildinfo_sonarqube, capsys):
             assert captured[1] == "org.sonarsource.sonarqube sonar-application zip "
 
 
+def test_publish_artifact_upload_file_sonarqube_cli(buildinfo_sonarqube_cli, capsys):
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
+        artifactory = MagicMock(**{'download.return_value': "/tmp/sonarqube-cli-0.6.0.500-linux-x64.zip"})
+        binaries = Binaries("test_bucket")
+        with patch.object(binaries, 'upload_eclipse_update_site_unzip') as mock_upload_eclipse_update_site_unzip, \
+            patch.object(binaries, 'upload_sonarlint_p2_site') as mock_upload_sonarlint_p2_site, \
+            patch.object(client, 'upload_file') as upload_file:
+            version = buildinfo_sonarqube_cli.get_version()
+            publish_artifact(artifactory, binaries, buildinfo_sonarqube_cli.get_artifacts_to_publish(), version, "repo")
+            upload_file.assert_called_with(
+                '/tmp/sonarqube-cli-0.6.0.500-linux-x64.zip.asc', 'test_bucket',
+                'Distribution/sonarqube-cli/0.6.0.500/linux/sonarqube-cli-0.6.0.500-linux-x64.zip.asc')
+            captured = capsys.readouterr().out.split('\n')
+            assert captured[0] == 'publishing org.sonarsource.sonarqube:sonarqube-cli:zip:linux-x64#0.6.0.500'
+            assert captured[1] == 'org.sonarsource.sonarqube sonarqube-cli zip linux-x64'
+            assert captured[2] == 'uploaded /tmp/sonarqube-cli-0.6.0.500-linux-x64.zip to s3://test_bucket/Distribution/sonarqube-cli/0.6.0.500/linux/sonarqube-cli-0.6.0.500-linux-x64.zip'
+            mock_upload_eclipse_update_site_unzip.assert_not_called()
+            mock_upload_sonarlint_p2_site.assert_not_called()
+
+
 def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
     binaries_session = MagicMock()
     client = MagicMock()
@@ -144,23 +181,23 @@ def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
                    's3://test_bucket/CommercialDistribution/dummy/dummy-1.0.2.456.jar.asc'
             mock_upload_eclipse_update_site_unzip.assert_not_called()
             mock_upload_sonarlint_p2_site.assert_not_called()
-            # org (with qualifier: hierarchical path version/platform/filename)
+            # org (with qualifier: flat path — hierarchical layout is only for sonarqube-cli)
             version = buildinfo_org.get_version()
             publish_artifact(artifactory, binaries, buildinfo_org.get_artifacts_to_publish(), version, "repo")
             upload_file.assert_called_with('/tmp/dummy-1.0.2.456.jar.asc', 'test_bucket',
-                                           'Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.asc')
+                                           'Distribution/dummy/dummy-1.0.2.456-qualifier.jar.asc')
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == 'publishing org.sonarsource.dummy:dummy:jar:qualifier#1.0.2.456'
             assert captured[1] == 'org.sonarsource.dummy dummy jar qualifier'
-            assert captured[2] == 'uploaded /tmp/dummy-1.0.2.456.jar to s3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar'
+            assert captured[2] == 'uploaded /tmp/dummy-1.0.2.456.jar to s3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar'
             assert captured[3] == 'uploaded /tmp/dummy-1.0.2.456.jar.md5 to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.md5'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.md5'
             assert captured[4] == 'uploaded /tmp/dummy-1.0.2.456.jar.sha1 to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.sha1'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.sha1'
             assert captured[5] == 'uploaded /tmp/dummy-1.0.2.456.jar.sha256 to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.sha256'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.sha256'
             assert captured[6] == 'uploaded /tmp/dummy-1.0.2.456.jar.asc to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.asc'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.asc'
             mock_upload_eclipse_update_site_unzip.assert_not_called()
             mock_upload_sonarlint_p2_site.assert_not_called()
 


### PR DESCRIPTION
PREQ-4535 scope hierarchical binaries layout to sonarqube-cli

## Summary
- limit hierarchical binaries paths to `sonarqube-cli` so other qualified artifacts keep their legacy flat URLs
- keep revoke backward-compatible by deleting both the flat key and the legacy hierarchical key for non-`sonarqube-cli` qualified artifacts published during the `v6.4.0` rollout window
- add test coverage for scoped upload behavior and backward-compatible delete behavior

## Context
PREQ-4535 introduced hierarchical `product/version/platform/file` paths for all qualified artifacts. That changed binaries URLs for products beyond `sonarqube-cli` and risks breaking repositories that rely on the legacy flat layout.

This change narrows the new layout to `sonarqube-cli`, which was the original target, while preserving cleanup compatibility for artifacts already published by the broader `v6.4.0` behavior.

## Breaking changes
- no breaking change intended for existing consumers
- `sonarqube-cli` continues to use the hierarchical layout introduced for PREQ-4535
- other products resume publishing qualified artifacts to the legacy flat path on future releases

## Test plan
- [x] `python -m pytest tests/utils/test_release.py tests/binaries_test.py -q --override-ini=\"addopts=\"`