### PR TITLE
PREQ-4535 Opt-in hierarchical layout for qualified binaries

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,11 @@ on:
         description: Flag to enable the publication to binaries
         default: false
         required: false
+      binariesHierarchicalQualifierLayout:
+        type: boolean
+        description: If true, qualified artifacts use version/platform subfolders on binaries (PREQ-4535)
+        default: false
+        required: false
       publishJavadoc:
         type: boolean
         description: Flag to enable the javadoc publication
@@ -248,6 +253,7 @@ jobs:
           publish_to_binaries: ${{ inputs.publishToBinaries }}  # Used only if the binaries are delivered to customers
           slack_channel: ${{ inputs.slackChannel }}
           dry_run: ${{ inputs.dryRun }}
+          binaries_hierarchical_qualifier_layout: ${{ inputs.binariesHierarchicalQualifierLayout }}
         env:
           PYTHONUNBUFFERED: 1
           ARTIFACTORY_ACCESS_TOKEN: ${{ steps.parse_vault.outputs.artifactory_access_token }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToBinaries: false # enable the publication to binaries
+      binariesHierarchicalQualifierLayout: false # PREQ-4535: qualified binaries under version/platform/ (opt-in)
       binariesS3Bucket: downloads-cdn-eu-central-1-prod # S3 bucket to use for the binaries
       publishJavadoc: false # enable the publication of the Javadoc to https://javadocs.sonarsource.org/
       publicRelease: false # define if the Javadoc is stored in 'sonarsource-public-releases' (or 'sonarsource-private-releases' if false)
@@ -47,6 +48,7 @@ Notes:
 
 - `publishToBinaries`: Only if the binaries are delivered to customers - "binaries" is an AWS S3 bucket. The `ARTIFACTORY_DEPLOY_REPO`
   environment variable is required in the release Build Info.
+- `binariesHierarchicalQualifierLayout`: When `true`, artifacts with a Maven classifier are published under `product/version/platform/filename` on binaries (PREQ-4535). Default `false` keeps the legacy flat layout. Revoke deletes both possible keys for qualified artifacts.
 - `isDummyProject`: The _dummy_ projects are treated differently regarding alerts and metrics. E.g.: in Datadog, the stats from dummy
   projects are excluded from some dashboards.
 

--- a/main/action.yml
+++ b/main/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: "Don't actually do anything, report what would have been done."
     default: 'false'
     required: false
+  binaries_hierarchical_qualifier_layout:
+    description: "If true, publish qualified artifacts under product/version/platform/filename on binaries (PREQ-4535)."
+    required: false
 outputs:
   promote:
     description: "Output to detect if promote was executed"

--- a/main/release/main.py
+++ b/main/release/main.py
@@ -68,7 +68,10 @@ def main():
         artifactory.promote(release_request, buildinfo)
         set_output("promote", 'done')  # There is no value to do it except to not break existing workflows
         if github.is_publish_to_binaries():
-            binaries = Binaries(binaries_bucket_name)
+            hierarchical_qualifier_layout = (
+                os.environ.get('INPUT_BINARIES_HIERARCHICAL_QUALIFIER_LAYOUT', '').strip().lower() == 'true'
+            )
+            binaries = Binaries(binaries_bucket_name, hierarchical_qualifier_layout=hierarchical_qualifier_layout)
             publish_all_artifacts_to_binaries(artifactory, binaries, release_request, buildinfo)
             set_output("publish_to_binaries", "done")  # There is no value to do it except to not break existing workflows
         notify_slack(f"Successfully released {release_request.project}:{release_request.version}")

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -88,13 +88,10 @@ class Binaries:
 
     def s3_upload(self, artifact_file, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        platform_folder = None
         if self.use_hierarchical_qualifier_layout(qual):
-            platform_folder = self.qual_to_platform_folder(qual)
-        if platform_folder:
-            file_bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
+            file_bucket_key = self.get_hierarchical_bucket_key(root_bucket_key, filename, version, qual)
         else:
-            file_bucket_key = f"{root_bucket_key}/{filename}"
+            file_bucket_key = self.get_flat_bucket_key(root_bucket_key, filename)
 
         self.s3_client.upload_file(artifact_file, self.binaries_bucket_name, file_bucket_key)
         print(f'uploaded {artifact_file} to s3://{self.binaries_bucket_name}/{file_bucket_key}')

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -18,7 +18,7 @@ REDDEER_AID = "org.eclipse.reddeer.site"
 UPLOAD_CHECKSUMS = ["md5", "sha1", "sha256", "asc"]
 
 # Map artifact qualifier (e.g. linux-x64, darwin-arm64) to folder name for hierarchical S3 structure.
-# Used to produce binaries.sonarsource.com layout: product/version/platform/file
+# Used only when Binaries.hierarchical_qualifier_layout is True and the artifact has a qualifier (PREQ-4535).
 QUAL_TO_PLATFORM_FOLDER = {
     "linux": "linux",
     "linux-x64": "linux",
@@ -39,8 +39,9 @@ QUAL_TO_PLATFORM_FOLDER = {
 
 
 class Binaries:
-    def __init__(self, binaries_bucket_name: str):
+    def __init__(self, binaries_bucket_name: str, hierarchical_qualifier_layout: bool = False):
         self.binaries_bucket_name = binaries_bucket_name
+        self.hierarchical_qualifier_layout = hierarchical_qualifier_layout
         self.binaries_session = boto3.Session(
             aws_access_key_id=binaries_aws_access_key_id,
             aws_secret_access_key=binaries_aws_secret_access_key,
@@ -75,9 +76,21 @@ class Binaries:
         # Fallback: use first segment before hyphen (e.g. linux-x64 -> linux)
         return qual.split("-")[0].lower() if "-" in qual else qual.lower()
 
+    def use_hierarchical_qualifier_layout(self, qual):
+        return bool(qual) and self.hierarchical_qualifier_layout
+
+    def get_flat_bucket_key(self, root_bucket_key, filename):
+        return f"{root_bucket_key}/{filename}"
+
+    def get_hierarchical_bucket_key(self, root_bucket_key, filename, version, qual):
+        platform_folder = self.qual_to_platform_folder(qual)
+        return f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
+
     def s3_upload(self, artifact_file, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        platform_folder = self.qual_to_platform_folder(qual) if qual else None
+        platform_folder = None
+        if self.use_hierarchical_qualifier_layout(qual):
+            platform_folder = self.qual_to_platform_folder(qual)
         if platform_folder:
             file_bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
         else:
@@ -167,14 +180,14 @@ class Binaries:
 
     def s3_delete(self, filename, gid, aid, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
-        platform_folder = self.qual_to_platform_folder(qual) if qual else None
-        if platform_folder:
-            bucket_key = f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
-        else:
-            bucket_key = f"{root_bucket_key}/{filename}"
+        bucket_keys = [self.get_flat_bucket_key(root_bucket_key, filename)]
+        if qual:
+            # Remove both possible keys: flat (legacy / flag-off) and hierarchical (flag-on or v6.4.0).
+            bucket_keys.append(self.get_hierarchical_bucket_key(root_bucket_key, filename, version, qual))
 
-        self.s3_client.delete_object(Bucket=self.binaries_bucket_name, Key=bucket_key)
-        print(f'deleted {bucket_key}')
+        for bucket_key in dict.fromkeys(bucket_keys):
+            self.s3_client.delete_object(Bucket=self.binaries_bucket_name, Key=bucket_key)
+            print(f'deleted {bucket_key}')
 
         if aid == SONARLINT_AID:
             version_bucket_key = f"{root_bucket_key}/{version}/"

--- a/main/tests/binaries_test.py
+++ b/main/tests/binaries_test.py
@@ -69,6 +69,15 @@ def test_qual_to_platform_folder():
     assert Binaries.qual_to_platform_folder('unknown-platform') == 'unknown'
 
 
+def test_use_hierarchical_qualifier_layout_flag():
+    flat = Binaries('bucket', hierarchical_qualifier_layout=False)
+    hier = Binaries('bucket', hierarchical_qualifier_layout=True)
+    assert flat.use_hierarchical_qualifier_layout('linux-x64') is False
+    assert hier.use_hierarchical_qualifier_layout('linux-x64') is True
+    assert hier.use_hierarchical_qualifier_layout('') is False
+
+
+
 @pytest.mark.parametrize(
     'group_id, root_bucket_key',
     [
@@ -83,3 +92,19 @@ def test_s3_delete_common_case(group_id, root_bucket_key):
     with patch('boto3.Session', return_value=binaries_session):
         Binaries('bucket').s3_delete('filename', group_id, "aid", 'version')
     client.delete_object.assert_called_once_with(Bucket='bucket', Key=f'{root_bucket_key}/aid/filename')
+
+
+
+def test_s3_delete_qualified_deletes_flat_and_hierarchical():
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
+        Binaries('bucket').s3_delete(
+            'sonarqube-cli-1.0.0-linux-x64.zip', 'org.sonarsource.sonarqube', 'sonarqube-cli', '1.0.0', 'linux-x64')
+    client.delete_object.assert_has_calls([
+        call(Bucket='bucket', Key='Distribution/sonarqube-cli/sonarqube-cli-1.0.0-linux-x64.zip'),
+        call(Bucket='bucket', Key='Distribution/sonarqube-cli/1.0.0/linux/sonarqube-cli-1.0.0-linux-x64.zip')
+    ])
+    assert client.delete_object.call_count == 2
+

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -76,6 +76,20 @@ def buildinfo_sonarqube():
     })
 
 
+@fixture
+def buildinfo_sonarqube_cli():
+    return BuildInfo({
+        "buildInfo": {
+            "modules": [{
+                "properties": {
+                    "artifactsToPublish": "org.sonarsource.sonarqube:sonarqube-cli:zip:linux-x64",
+                },
+                "id": "org.sonarsource.sonarqube:sonarqube-cli:0.6.0.500",
+            }]
+        }
+    })
+
+
 def test_publish_artifact_s3_upload(buildinfo_com, buildinfo_org, capsys):
     client = MagicMock()
     with patch('boto3.client', return_value=client):
@@ -115,6 +129,29 @@ def test_publish_artifact_s3_upload_sonarqube(buildinfo_sonarqube, capsys):
             assert captured[1] == "org.sonarsource.sonarqube sonar-application zip "
 
 
+def test_publish_artifact_upload_file_sonarqube_cli(buildinfo_sonarqube_cli, capsys):
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
+        artifactory = MagicMock(**{'download.return_value': "/tmp/sonarqube-cli-0.6.0.500-linux-x64.zip"})
+        binaries = Binaries("test_bucket", hierarchical_qualifier_layout=True)
+        with patch.object(binaries, 'upload_eclipse_update_site_unzip') as mock_upload_eclipse_update_site_unzip, \
+            patch.object(binaries, 'upload_sonarlint_p2_site') as mock_upload_sonarlint_p2_site, \
+            patch.object(client, 'upload_file') as upload_file:
+            version = buildinfo_sonarqube_cli.get_version()
+            publish_artifact(artifactory, binaries, buildinfo_sonarqube_cli.get_artifacts_to_publish(), version, "repo")
+            upload_file.assert_called_with(
+                '/tmp/sonarqube-cli-0.6.0.500-linux-x64.zip.asc', 'test_bucket',
+                'Distribution/sonarqube-cli/0.6.0.500/linux/sonarqube-cli-0.6.0.500-linux-x64.zip.asc')
+            captured = capsys.readouterr().out.split('\n')
+            assert captured[0] == 'publishing org.sonarsource.sonarqube:sonarqube-cli:zip:linux-x64#0.6.0.500'
+            assert captured[1] == 'org.sonarsource.sonarqube sonarqube-cli zip linux-x64'
+            assert captured[2] == 'uploaded /tmp/sonarqube-cli-0.6.0.500-linux-x64.zip to s3://test_bucket/Distribution/sonarqube-cli/0.6.0.500/linux/sonarqube-cli-0.6.0.500-linux-x64.zip'
+            mock_upload_eclipse_update_site_unzip.assert_not_called()
+            mock_upload_sonarlint_p2_site.assert_not_called()
+
+
 def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
     binaries_session = MagicMock()
     client = MagicMock()
@@ -144,23 +181,23 @@ def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
                    's3://test_bucket/CommercialDistribution/dummy/dummy-1.0.2.456.jar.asc'
             mock_upload_eclipse_update_site_unzip.assert_not_called()
             mock_upload_sonarlint_p2_site.assert_not_called()
-            # org (with qualifier: hierarchical path version/platform/filename)
+            # org (with qualifier: flat path when binaries_hierarchical_qualifier_layout is off)
             version = buildinfo_org.get_version()
             publish_artifact(artifactory, binaries, buildinfo_org.get_artifacts_to_publish(), version, "repo")
             upload_file.assert_called_with('/tmp/dummy-1.0.2.456.jar.asc', 'test_bucket',
-                                           'Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.asc')
+                                           'Distribution/dummy/dummy-1.0.2.456-qualifier.jar.asc')
             captured = capsys.readouterr().out.split('\n')
             assert captured[0] == 'publishing org.sonarsource.dummy:dummy:jar:qualifier#1.0.2.456'
             assert captured[1] == 'org.sonarsource.dummy dummy jar qualifier'
-            assert captured[2] == 'uploaded /tmp/dummy-1.0.2.456.jar to s3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar'
+            assert captured[2] == 'uploaded /tmp/dummy-1.0.2.456.jar to s3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar'
             assert captured[3] == 'uploaded /tmp/dummy-1.0.2.456.jar.md5 to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.md5'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.md5'
             assert captured[4] == 'uploaded /tmp/dummy-1.0.2.456.jar.sha1 to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.sha1'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.sha1'
             assert captured[5] == 'uploaded /tmp/dummy-1.0.2.456.jar.sha256 to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.sha256'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.sha256'
             assert captured[6] == 'uploaded /tmp/dummy-1.0.2.456.jar.asc to ' \
-                                  's3://test_bucket/Distribution/dummy/1.0.2.456/qualifier/dummy-1.0.2.456-qualifier.jar.asc'
+                                  's3://test_bucket/Distribution/dummy/dummy-1.0.2.456-qualifier.jar.asc'
             mock_upload_eclipse_update_site_unzip.assert_not_called()
             mock_upload_sonarlint_p2_site.assert_not_called()
 


### PR DESCRIPTION
## Summary
Adds optional `binariesHierarchicalQualifierLayout` (default `false`) so consumers can opt into `product/version/platform/filename` on binaries for artifacts with a Maven classifier. Default keeps the legacy flat layout.

Revoke deletes **both** flat and hierarchical S3 keys when a qualifier is present (covers flag on/off and prior 6.4.0 behavior).

## Related
- PREQ-4535
- Supersedes the hardcoded `sonarqube-cli`-only approach from the earlier PR; consumers (e.g. `sonarqube-cli`) should pass `binariesHierarchicalQualifierLayout: true` **after** this workflow input is available on `master`.

## Tests
`pytest` in `main/`: 61 passed.