### PR TITLE
BUILD-10765 Update SonarSource/gh-action_releasability to 3.0.4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -205,7 +205,7 @@ jobs:
             echo "skip_releasability_checks=false" >> "${GITHUB_OUTPUT}"
           fi
 
-      - uses: SonarSource/gh-action_releasability@d629774c84a04cddfcffa334490d6688c459db7f # 3.0.2
+      - uses: SonarSource/gh-action_releasability@683b9a1ffd08c3a23af1d1bffb67a9d7bcfb1b08 # 3.0.4
         id: releasability
         if: ${{ steps.releasability_prerequisites.outputs.skip_releasability_checks != 'true' && inputs.dryRun != true }}
         with:


### PR DESCRIPTION
Update `SonarSource/gh-action_releasability` to `683b9a1ffd08c3a23af1d1bffb67a9d7bcfb1b08` (3.0.4) for compliance with allowed versions.