### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to 6.5.0

### DIFF
--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@05db046385edc88eb40554c2677c1d726f4987f6 # master
+        uses: SonarSource/gh-action_release/download-build@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
@@ -74,7 +74,7 @@ jobs:
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@05db046385edc88eb40554c2677c1d726f4987f6 # master
+        uses: SonarSource/gh-action_release/maven-central-sync@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
           central-url: https://central.sonatype.com


### PR DESCRIPTION
**Important:** Update `SonarSource/gh-action_release` to `c52861bb0e5dd564187f3fd74e048f20aef0f761` (6.5.0) for compliance with allowed versions.

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-10-04/23899/5