### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to 6.5.0

### DIFF
--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -84,7 +84,7 @@ jobs:
           echo "path: $groupIdPath"
           echo "groupIdPath=${groupIdPath}" >> $GITHUB_OUTPUT
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@05db046385edc88eb40554c2677c1d726f4987f6 # master
+        uses: SonarSource/gh-action_release/download-build@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
         with:
           flat-download: true
           build-number: ${{ steps.get_version.outputs.build }}
@@ -100,7 +100,7 @@ jobs:
       - name: List javadoc files
         run: ls "${{ steps.local_repo.outputs.dir }}/javadoc/${{ inputs.version || github.event.release.tag_name }}"
       - name: Publish javadoc files to S3
-        uses: SonarSource/gh-action_release/aws-s3@05db046385edc88eb40554c2677c1d726f4987f6 # master
+        uses: SonarSource/gh-action_release/aws-s3@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
         with:
           command: cp
           flags: --recursive
@@ -111,7 +111,7 @@ jobs:
           aws_session_token: ${{ fromJSON(steps.secrets.outputs.vault).javadoc_aws_security_token }}
           aws_region: eu-central-1
       - name: Delete dir named latest in S3
-        uses: SonarSource/gh-action_release/aws-s3@05db046385edc88eb40554c2677c1d726f4987f6 # master
+        uses: SonarSource/gh-action_release/aws-s3@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
         with:
           command: rm
           source: s3://javadocs-cdn-eu-central-1-prod/${{ inputs.javadocDestinationDirectory || github.event.repository.name }}/latest
@@ -122,7 +122,7 @@ jobs:
         continue-on-error: true # the first time a project publish javadoc, there is no latest dir available
       - name: Upload to dir named latest in S3
         id: upload-latest
-        uses: SonarSource/gh-action_release/aws-s3@05db046385edc88eb40554c2677c1d726f4987f6 # master
+        uses: SonarSource/gh-action_release/aws-s3@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
         with:
           command: cp
           flags: --recursive


### PR DESCRIPTION
**Important:** Update `SonarSource/gh-action_release` to `c52861bb0e5dd564187f3fd74e048f20aef0f761` (6.5.0) for compliance with allowed versions.

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-10-04/23899/5