### PR TITLE
BUILD-10930: Add useNpmTrustedPublisher input to gh-action_release workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,6 +82,11 @@ on:
         description: Publish Javascript artifacts to https://www.npmjs.com
         default: false
         required: false
+      useNpmTrustedPublisher:
+        type: boolean
+        description: Use npm Trusted Publishers (OIDC) instead of Vault token for npm publish
+        default: false
+        required: false
       skipPythonReleasabilityChecks:
         type: boolean
         description: Skip releasability checks for Python projects
@@ -327,6 +332,7 @@ jobs:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       slackChannel: ${{ inputs.slackChannel }}
+      useNpmTrustedPublisher: ${{ inputs.useNpmTrustedPublisher }}
 
   datadog:
     name: Push results to datadog

--- a/.github/workflows/npmjs.yaml
+++ b/.github/workflows/npmjs.yaml
@@ -36,11 +36,17 @@ name: NpmJS
         description: Slack channel to post notifications
         default: build
         required: false
+      useNpmTrustedPublisher:
+        type: boolean
+        description: Use npm Trusted Publishers (OIDC) instead of Vault token for npm publish
+        default: false
+        required: false
 
 jobs:
   publish-to-npm:
     name: Publish to npmjs
     runs-on: github-ubuntu-latest-s
+    environment: ${{ inputs.useNpmTrustedPublisher && 'release' || '' }}
     permissions:
       id-token: write
       contents: read
@@ -69,7 +75,7 @@ jobs:
           url: ${{ inputs.vaultAddr }}
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ inputs.artifactoryRoleSuffix }} access_token | artifactory_access_token;
-            development/kv/data/${{ inputs.vaultTokenKey }} sonartech_npm_token | npm_token;
+            ${{ !inputs.useNpmTrustedPublisher && format('development/kv/data/{0} sonartech_npm_token | npm_token;', inputs.vaultTokenKey) || '' }}
             development/kv/data/slack webhook | slack_webhook;
 
       - name: Setup JFrog
@@ -103,6 +109,11 @@ jobs:
           tar -xzf "$file" -C package --strip-components=1
           echo "Package extracted to ./package"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+
       - name: Update package version
         working-directory: ${{ steps.local_repo.outputs.dir }}/package
         run: npm version --no-git-tag-version ${{ steps.get_version.outputs.version }}
@@ -115,6 +126,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Configure npm registry
+        if: ${{ !inputs.useNpmTrustedPublisher }}
         run: |
           if [ -f developer_repo/.github/workflows/.npmrc ]; then
             echo ".npmrc file found in developer repository at .github/workflows/.npmrc."
@@ -129,11 +141,19 @@ jobs:
           NPM_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).npm_token }}
 
       - name: Publish npm package to npmjs
+        if: ${{ !inputs.useNpmTrustedPublisher }}
         working-directory: ${{ steps.local_repo.outputs.dir }}/package
         env:
           NPM_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).npm_token }}
         run: |
           npm publish
+
+      - name: Publish npm package to npmjs (Trusted Publisher)
+        if: ${{ inputs.useNpmTrustedPublisher }}
+        working-directory: ${{ steps.local_repo.outputs.dir }}/package
+        run: |
+          npm publish --provenance --access public
+
       - name: Notify on Failure
         if: ${{ failure() }}
         uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
       publishToPyPI: false # for OSS projects only, publish PyPI artifacts to https://pypi.org/
       publishToTestPyPI: false # for OSS projects only, publish PyPI artifacts to https://test.pypi.org/
       publishToNpmJS: false # for OSS projects only, publish npm artifacts to https://www.npmjs.com/
+      useNpmTrustedPublisher: false # use npm Trusted Publishers (OIDC) instead of Vault token for npm publish
       skipPythonReleasabilityChecks: false # skip releasability checks for Python projects
       skipJavascriptReleasabilityChecks: false # skip releasability checks for Javascript projects
       slackChannel: build # define the Slack channel to use for notifications
@@ -54,6 +55,16 @@ Notes:
 
 When releasing a npm project using this action, you can specify a custom .npmrc file. To do this, place your .npmrc file in the
 .github/workflows/ directory of the repository you wish to release. The action will automatically use this configuration.
+
+## npm Trusted Publishers (OIDC)
+
+Setting `useNpmTrustedPublisher: true` switches npm publishing from the Vault-stored static token to [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers) (GitHub Actions OIDC). The package is published with `--provenance`, linking it to the source commit and workflow.
+
+**Requirements before enabling:**
+1. Configure a Trusted Publisher on [npmjs.org](https://www.npmjs.com/) for each package, referencing the exact product repo, workflow filename, and environment `release`.
+2. Create a `release` environment in the product repo on GitHub (Settings → Environments) and configure branch rules.
+3. The calling workflow must have `id-token: write` permission (already standard for Vault-based workflows).
+4. The Vault permission `development/kv/data/npmjs` is no longer needed when using Trusted Publishers.
 
 ## Releasability check
 


### PR DESCRIPTION
BUILD-10930: Add useNpmTrustedPublisher input to gh-action_release workflows

Adds a new optional boolean input \`useNpmTrustedPublisher\` (default: \`false\`) to both \`main.yaml\` and \`npmjs.yaml\`, enabling opt-in support for npm Trusted Publishers (OIDC-based publishing) without affecting existing callers.

**Changes:**
- \`main.yaml\`: declares the new input and passes it through to the \`npmjs\` job call
- \`npmjs.yaml\`:
  - Splits the Vault secrets step — common secrets (Artifactory, Slack) remain in the existing \`secrets\` step; npm token retrieval moved to a new \`npm-secrets\` step guarded by \`if: !inputs.useNpmTrustedPublisher\`
  - "Configure npm registry" and "Publish npm package" steps are skipped when \`useNpmTrustedPublisher: true\`
  - New "Publish npm package (Trusted Publisher)" step runs \`npm publish --provenance\` when \`useNpmTrustedPublisher: true\`

**Backwards compatibility:** default is \`false\` — all existing release workflows are unaffected. The \`id-token: write\` permission required for OIDC was already present on the job.

The PR includes changes to README. There is a follow-up task to review the documentation in README, Xtranet and update properly.