### PR TITLE
BUILD-11106 Stop 422 cascade from Release Immutability (v6.8.1)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -149,7 +149,7 @@ jobs:
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
           # During development change this to your branch name to run it in another repository
-          ref: feat/smarini/BUILD-11106-immutability-safe-rollback
+          ref: ${{ github.ref }}
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -367,7 +367,7 @@ jobs:
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
           # During development change this to your branch name to run it in another repository
-          ref: feat/smarini/BUILD-11106-immutability-safe-rollback
+          ref: ${{ github.ref }}
           path: gh-action_release
 
       - name: Vault

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -149,7 +149,7 @@ jobs:
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
           # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          ref: feat/smarini/BUILD-11106-immutability-safe-rollback
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -367,7 +367,7 @@ jobs:
           repository: SonarSource/gh-action_release
           # This property is changed during the release process to reference the correct tag
           # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          ref: feat/smarini/BUILD-11106-immutability-safe-rollback
           path: gh-action_release
 
       - name: Vault

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -228,13 +228,13 @@ jobs:
           repository: ${{ github.event.repository.name }}
           version: ${{ inputs.version || github.event.release.tag_name }}
 
-      - name: Revoke release on releasability check failure
+      - name: Release rollback notice
         if: failure() && steps.releasability.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version || github.event.release.tag_name }}
+          RELEASE_ID: ${{ inputs.releaseId || github.event.release.id }}
         run: |
-          gh api repos/${{ github.repository }}/releases/${{ inputs.releaseId || github.event.release.id }} -X PATCH -F draft=true
-          gh api repos/${{ github.repository }}/git/refs/tags/${{ inputs.version || github.event.release.tag_name }} -X DELETE
+          echo "::warning::Release NOT revoked on GitHub (immutability-safe mode since v6.8.1). The GitHub release and tag are preserved so you can retry without triggering a new build. Artifacts were revoked in JFrog/S3. Fix the underlying issue and rerun this workflow via 'Run workflow' (workflow_dispatch) with version=${VERSION} and releaseId=${RELEASE_ID}."
 
       - name: Send Slack notification on releasability check failure
         if: failure() && steps.releasability.outcome == 'failure'
@@ -248,7 +248,7 @@ jobs:
               "attachments": [
                 {
                   "color": "#ff0000",
-                  "text": "Releasability checks failed in `${{ github.repository }}`. Release `${{ inputs.version || github.event.release.tag_name }}` was revoked. Publish the release again after resolving the issue. \n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                  "text": "Releasability checks failed in `${{ github.repository }}`. Release `${{ inputs.version || github.event.release.tag_name }}` is *kept* (not revoked) — retry without rebuilding. JFrog/S3 artifacts were revoked.\n*To retry:* <${{ github.server_url }}/${{ github.repository }}/actions/workflows/release.yml|Run workflow> with `version=${{ inputs.version || github.event.release.tag_name }}` and `releaseId=${{ inputs.releaseId || github.event.release.id }}`\n*To abandon:* delete the release and tag manually (`gh release delete <tag> --cleanup-tag`).\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to failed run>"
                 }
               ]
             }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ Setting `useNpmTrustedPublisher: true` switches npm publishing from the Vault-st
 3. The calling workflow must have `id-token: write` permission (already standard for Vault-based workflows).
 4. The Vault permission `development/kv/data/npmjs` is no longer needed when using Trusted Publishers.
 
+## Recovering from a failed release
+
+Since v6.8.1, when a release workflow fails (releasability checks, Artifactory promotion, etc.) the GitHub release and its tag are **left intact**. This preserves the ability to retry without triggering a full rebuild (~3h for some projects).
+
+### What happens on failure
+
+- The GitHub release stays published (visible in the Releases tab).
+- The Git tag stays in place.
+- JFrog/S3 artifacts **are** revoked (no broken artifacts are available to downstream consumers).
+- You will see a `::warning::` annotation in the Actions log and a Slack message with retry instructions.
+
+### Retrying without rebuilding
+
+1. Fix the root cause (e.g. merge the missing Jira fix-version, resolve the releasability check).
+2. Go to **Actions → Release → Run workflow** (or use `gh workflow run`).
+3. Fill in:
+   - `version` — the tag name (e.g. `1.2.3.456`), visible in the failed run or the Slack notification.
+   - `releaseId` — the GitHub release ID, also visible in the Slack notification or the failed run annotations.
+4. Run the workflow. No new build is needed.
+
+### Abandoning a failed release
+
+If you decide not to retry with the same version:
+
+```sh
+gh release delete <tag> --cleanup-tag --yes --repo <org/repo>
+```
+
+> **Note:** After deleting the release, the tag name is protected by GitHub's resurrection protection — it cannot be reused for a new release. A new build (and new tag) is required.
+
 ## Releasability check
 
 To perform a releasability check for a given version without performing an actual release, run

--- a/main/release/main.py
+++ b/main/release/main.py
@@ -19,10 +19,12 @@ MANDATORY_ENV_VARIABLES = [
 
 @Dryable(logging_msg='{function}()')
 def abort_release(github: GitHub, artifactory: Artifactory, binaries: Binaries, rr: ReleaseRequest):
-    print("::error Aborting release")
+    print("::error::Release failed. JFrog/S3 artifacts are being revoked. "
+          "The GitHub release and tag are preserved (immutability-safe mode since v6.8.1) — "
+          "retry via workflow_dispatch with the same version and releaseId, no rebuild needed.")
     github.revoke_release()
     revoke_release(artifactory, binaries, rr)
-    set_output("release", f"{rr.project}:{rr.buildnumber} revoked")
+    set_output("release", f"{rr.project}:{rr.buildnumber} aborted")
 
 
 def check_params(buildinfo=BuildInfo({})):
@@ -73,7 +75,10 @@ def main():
             set_output("publish_to_binaries", "done")  # There is no value to do it except to not break existing workflows
         notify_slack(f"Successfully released {release_request.project}:{release_request.version}")
     except Exception as e:
-        notify_slack(f"Failed to release {release_request.project}:{release_request.version}")
+        notify_slack(
+            f"Failed to release {release_request.project}:{release_request.version}. "
+            f"GitHub release and tag are preserved — retry via workflow_dispatch, no rebuild needed."
+        )
         abort_release(github, artifactory, binaries, release_request)
         raise e
 

--- a/main/release/utils/github.py
+++ b/main/release/utils/github.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-import requests
 import logging
 
 from release.utils.dryrun import DryRunHelper
@@ -97,12 +96,14 @@ class GitHub:
         release = self._get_release()
         if release is None:
             return
-        tag_name = release["tag_name"]
-        headers = {'Authorization': f'token {self.token}'}
-        payload = {'draft': True, 'tag_name': tag_name}
-        requests.patch(release['url'], json=payload, headers=headers)
-        # Delete tag
-        requests.delete(self._get_repository().get("git_refs_url").replace("{/sha}", f'/tags/{tag_name}'), headers=headers)
+        tag_name = release.get("tag_name", "unknown")
+        self.logger.warning(
+            "revoke_release: GitHub release '%s' is NOT being unpublished or deleted "
+            "(immutability-safe mode since v6.8.1). The tag and version are preserved so "
+            "the release can be retried via workflow_dispatch without triggering a new build. "
+            "JFrog/S3 artifacts have already been revoked by the caller.",
+            tag_name,
+        )
 
     @staticmethod
     def is_publish_to_binaries():

--- a/main/tests/github_test.py
+++ b/main/tests/github_test.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 import re
 import pytest
 
@@ -157,8 +157,6 @@ def test_must_succeed_with_plus_version_separator(mock_release_event):
 
 
 @patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release', 'GITHUB_SHA': 'sha', 'GITHUB_TOKEN': 'token'}, clear=True)
-@patch('requests.delete')
-@patch('requests.patch')
 @patch('release.utils.github.json.load',
        return_value={
            'repository': {
@@ -169,20 +167,32 @@ def test_must_succeed_with_plus_version_separator(mock_release_event):
                'url': 'release_url'
            },
        })
-def test_revoke_release(mock_release_event, mock_update_release, mock_delete_tag):
+def test_revoke_release_is_noop(mock_release_event):
+    """revoke_release() must NOT make any HTTP calls (immutability-safe since v6.8.1)."""
     with patch('release.utils.github.open', mock_open()) as open_mock:
-        GitHub().revoke_release()
+        github = GitHub()
+        # Confirm no requests module is imported / used by capturing any stray calls
+        with patch.dict('sys.modules', {'requests': MagicMock()}) as mock_requests_mod:
+            github.revoke_release()
+            # The requests module must not have been called
+            mock_requests_mod['requests'].patch.assert_not_called()
+            mock_requests_mod['requests'].delete.assert_not_called()
         open_mock.assert_called_once()
         mock_release_event.assert_called_once()
-        mock_update_release.assert_called_once_with(
-            'release_url',
-            json={'draft': True, 'tag_name': '1.0.0.42'},
-            headers={'Authorization': f'token token'}
-        )
-        mock_delete_tag.assert_called_once_with(
-            'git_refs_url/tags/1.0.0.42',
-            headers={'Authorization': f'token token'}
-        )
+
+
+@patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'release', 'GITHUB_SHA': 'sha', 'GITHUB_TOKEN': 'token'}, clear=True)
+@patch('release.utils.github.json.load',
+       return_value={
+           'repository': {
+               'git_refs_url': 'git_refs_url{/sha}'
+           },
+           'release': None,
+       })
+def test_revoke_release_noop_when_release_is_none(mock_release_event):
+    """revoke_release() exits early when there is no release in the event payload."""
+    with patch('release.utils.github.open', mock_open()):
+        GitHub().revoke_release()  # must not raise
 
 
 @patch.dict(os.environ, {'INPUT_PUBLISH_TO_BINARIES': 'true'}, clear=True)

--- a/main/tests/main_test.py
+++ b/main/tests/main_test.py
@@ -8,9 +8,10 @@ import pytest
 from parameterized import parameterized
 
 from release.exceptions.invalid_input_parameters_exception import InvalidInputParametersException
-from release.main import main, set_output, check_params, MANDATORY_ENV_VARIABLES
+from release.main import abort_release, main, set_output, check_params, MANDATORY_ENV_VARIABLES
 from release.steps.ReleaseRequest import ReleaseRequest
 from release.utils.artifactory import Artifactory
+from release.utils.binaries import Binaries
 from release.utils.buildinfo import BuildInfo
 from release.utils.github import GitHub
 
@@ -22,6 +23,24 @@ def test_set_output():
         set_output('function', 'output')
 
         assert temp_file.read().decode("utf-8").strip() == "function=output"
+
+
+@patch('release.main.revoke_release')
+@patch('release.main.set_output')
+@patch.object(GitHub, 'revoke_release')
+def test_abort_release_logs_error_and_revokes_artifacts(mock_github_revoke, mock_set_output, mock_revoke_release):
+    """abort_release must print the immutability-safe error, call github.revoke_release,
+    revoke JFrog/S3 artifacts, and set the 'release' output."""
+    release_request = ReleaseRequest('org', 'project', 'version', '42', 'branch', 'sha')
+    github = GitHub.__new__(GitHub)
+    artifactory = Artifactory.__new__(Artifactory)
+    binaries = Binaries.__new__(Binaries)
+
+    abort_release(github, artifactory, binaries, release_request)
+
+    mock_github_revoke.assert_called_once()
+    mock_revoke_release.assert_called_once_with(artifactory, binaries, release_request)
+    mock_set_output.assert_called_once_with("release", "project:42 aborted")
 
 
 class MainTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **Problem**: When `gh-action_release` fails (releasability checks, Artifactory promotion), the rollback steps try to `PATCH draft=true` and `DELETE tag` on an immutable published release, both returning HTTP 422. The YAML step fails loudly; the Python path silently swallows the error and sends a misleading "revoked" Slack message.
- **Fix (v6.8.1)**: Replace the rollback steps with an immutability-safe no-op. The GitHub release and tag are **left intact**, so the dev can retry via `workflow_dispatch` without triggering a new ~3h build. JFrog/S3 artifacts are still revoked as before.
- **No consumer change required**: repos using `on: release: [published]` are unaffected.

## Changes

| File | Change |
|---|---|
| `.github/workflows/main.yaml` | Replaced `PATCH draft=true` + `DELETE tag` step with a `::warning::` annotation carrying version/releaseId for a one-click retry |
| `.github/workflows/main.yaml` | Slack failure message updated: release is kept, retry instructions, abandon path |
| `main/release/utils/github.py` | `revoke_release()` is now a no-op with a warning log; removed unused `requests` import |
| `main/release/main.py` | `abort_release()` and `notify_slack` failure call reflect new semantics |
| `main/tests/github_test.py` | Replaced HTTP-call assertions with no-HTTP-call assertions; added `test_abort_release_logs_error_and_revokes_artifacts` to cover `abort_release` body; all 16 tests pass |
| `README.md` | New **"Recovering from a failed release"** section |

> **Note**: The two `ref: feat/smarini/BUILD-11106-immutability-safe-rollback` lines in `main.yaml` (the self-checkout steps) are hardcoded for consumer testing only and **must be reverted to `${{ github.ref }}`** before merge. `scripts/release.sh` performs this substitution automatically as part of the v6.8.1 release cut.

## Testing — validated on [sonar-dummy-maven-enterprise](https://github.com/SonarSource/sonar-dummy-maven-enterprise) with immutability enabled

### Test 1 — Before this PR (current `@v6` on master)

**Goal**: confirm the 422 cascade exists.

- Enabled Release Immutability on `sonar-dummy-maven-enterprise`.
- Published a release with fake version `99.0.0.9999` (no CI build → releasability fails immediately).
- The "Revoke release" step attempted `PATCH draft=true` → **HTTP 422** (immutability blocked it); the step logged the error but did **not** fail the workflow — the release was silently left published with a misleading "revoked" Slack message.
- Run: [#24883687709 / job 72858251720](https://github.com/SonarSource/sonar-dummy-maven-enterprise/actions/runs/24883687709/job/72858251720) ✅ bug confirmed.

### Test 2 — With this PR branch (`@feat/smarini/BUILD-11106-immutability-safe-rollback`)

**Goal**: confirm no 422, release and tag preserved, retry instructions surfaced.

- Pinned `sonar-dummy-maven-enterprise` release workflow to this branch via [PR #129](https://github.com/SonarSource/sonar-dummy-maven-enterprise/pull/129).
- Published a release with fake version `100.0.0.10000` → releasability failed.
- **No `PATCH` or `DELETE` attempted**. The `::warning::` step fired with:
  ```
  Release NOT revoked on GitHub (immutability-safe mode since v6.8.1).
  The GitHub release and tag are preserved so you can retry without triggering a new build.
  Artifacts were revoked in JFrog/S3. Fix the underlying issue and rerun this workflow
  via 'Run workflow' (workflow_dispatch) with version=100.0.0.10000 and releaseId=313169043.
  ```
- Release `100.0.0.10000` and its tag remained intact on GitHub after the failed run.
- Run: [#24886375900 / job 72867297341](https://github.com/SonarSource/sonar-dummy-maven-enterprise/actions/runs/24886375900/job/72867297341) ✅ fix validated.

## Related

- Jira: [BUILD-11106](https://sonarsource.atlassian.net/browse/BUILD-11106)
- Epic: [BUILD-10870](https://sonarsource.atlassian.net/browse/BUILD-10870) — GitHub Security Hardening: Release and Tag Immutability
- Phase 2 (v7.0.0 draft-first via `workflow_dispatch`) will be a separate PR.

[BUILD-11106]: https://sonarsource.atlassian.net/browse/BUILD-11106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ