### PR TITLE
BUILD-11106 Draft-first v7 release flow (workflow_dispatch)

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -35,6 +35,7 @@ jobs:
     name: Test reusable workflow
     uses: ./.github/workflows/main.yaml
     with:
+      version: "0.0.0.0"
       dryRun: true
       publishToBinaries: false
       binariesS3Bucket: test-bucket

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,12 +7,8 @@ on:
     inputs:
       version:
         type: string
-        description: Version (alternative to release event)
-        required: false
-      releaseId:
-        type: string
-        description: Release ID (alternative to release event)
-        required: false
+        description: Full version including build number (e.g. 1.2.3.456). Required for v7 draft-first flow.
+        required: true
       dryRun:
         type: boolean
         description: Flag to enable the dry-run execution
@@ -124,7 +120,7 @@ jobs:
       id-token: write  # to authenticate via OIDC
       contents: write  # to revert a github release
     timeout-minutes: 30
-    if: ${{ inputs.dryRun == true || (github.event_name == 'release' && github.event.action == 'published') || (inputs.version != '' && inputs.releaseId != '') }}
+    if: ${{ inputs.dryRun == true || inputs.version != '' }}
     outputs:
       releasability: ${{ steps.release.outputs.releasability }}
       promote: ${{ steps.release.outputs.promote }}
@@ -155,6 +151,30 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ github.event.repository.name }}
+
+      - name: Create or reuse draft release
+        id: draft
+        if: ${{ inputs.dryRun != true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$VERSION" --repo "${{ github.repository }}" --json id,isDraft -q '.isDraft' 2>/dev/null | grep -q true; then
+            echo "Reusing existing draft release $VERSION"
+          elif gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::Release $VERSION already exists and is NOT a draft. Aborting to avoid duplicate publish."
+            exit 1
+          else
+            gh release create "$VERSION" \
+              --repo "${{ github.repository }}" \
+              --draft --generate-notes \
+              --target "$GITHUB_SHA"
+            echo "Created draft release $VERSION"
+          fi
+          release_id=$(gh release view "$VERSION" --repo "${{ github.repository }}" --json id -q '.id')
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -226,15 +246,14 @@ jobs:
           commit-sha: ${{ github.sha }}
           organization: ${{ github.repository_owner }}
           repository: ${{ github.event.repository.name }}
-          version: ${{ inputs.version || github.event.release.tag_name }}
+          version: ${{ inputs.version }}
 
       - name: Release rollback notice
         if: failure() && steps.releasability.outcome == 'failure'
         env:
-          VERSION: ${{ inputs.version || github.event.release.tag_name }}
-          RELEASE_ID: ${{ inputs.releaseId || github.event.release.id }}
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "::warning::Release NOT revoked on GitHub (immutability-safe mode since v6.8.1). The GitHub release and tag are preserved so you can retry without triggering a new build. Artifacts were revoked in JFrog/S3. Fix the underlying issue and rerun this workflow via 'Run workflow' (workflow_dispatch) with version=${VERSION} and releaseId=${RELEASE_ID}."
+          echo "::warning::Release $VERSION saved as draft. Fix the root cause and 'Re-run jobs'. No need for a new build."
 
       - name: Send Slack notification on releasability check failure
         if: failure() && steps.releasability.outcome == 'failure'
@@ -248,12 +267,12 @@ jobs:
               "attachments": [
                 {
                   "color": "#ff0000",
-                  "text": "Releasability checks failed in `${{ github.repository }}`. Release `${{ inputs.version || github.event.release.tag_name }}` is *kept* (not revoked) — retry without rebuilding. JFrog/S3 artifacts were revoked.\n*To retry:* <${{ github.server_url }}/${{ github.repository }}/actions/workflows/release.yml|Run workflow> with `version=${{ inputs.version || github.event.release.tag_name }}` and `releaseId=${{ inputs.releaseId || github.event.release.id }}`\n*To abandon:* delete the release and tag manually (`gh release delete <tag> --cleanup-tag`).\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to failed run>"
+                  "text": "Releasability checks failed in `${{ github.repository }}`. Fix the root cause and retry without rebuilding.\n*To retry:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Rerun release workflow `${{ inputs.version }}`>\n*Draft:* <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.version }}|View draft release `${{ inputs.version }}`>\n*To abandon:* `gh release delete ${{ inputs.version }} --cleanup-tag --yes`"
                 }
               ]
             }
 
-      - name: Release ${{ inputs.version || github.event.release.tag_name }}
+      - name: Release ${{ inputs.version }}
         id: release
         uses: ./gh-action_release/main
         with:
@@ -262,6 +281,7 @@ jobs:
           dry_run: ${{ inputs.dryRun }}
         env:
           PYTHONUNBUFFERED: 1
+          INPUT_VERSION: ${{ inputs.version }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ steps.parse_vault.outputs.artifactory_access_token }}
           BINARIES_AWS_DEPLOY: ${{ inputs.binariesS3Bucket }}  # Required for pushing the binaries
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -346,6 +366,27 @@ jobs:
       useNpmTrustedPublisher: ${{ inputs.useNpmTrustedPublisher }}
       githubEnvironment: ${{ inputs.githubEnvironment }}
 
+  publish:
+    name: Publish draft release
+    runs-on: sonar-xs
+    needs:
+      - release
+      - mavenCentral
+      - javadocPublication
+      - testPypi
+      - pypi
+      - npmjs
+    if: ${{ !failure() && !cancelled() && inputs.dryRun != true }}
+    permissions:
+      contents: write
+    steps:
+      - name: Promote draft to published (immutable)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          gh release edit "$INPUT_VERSION" --repo "${{ github.repository }}" --draft=false
+
   datadog:
     name: Push results to datadog
     runs-on: github-ubuntu-latest-s
@@ -357,6 +398,7 @@ jobs:
       - testPypi
       - pypi
       - npmjs
+      - publish
     if: ${{ always() && inputs.pushToDatadog && inputs.dryRun != true }}
     steps:
       # Clone gh-action_release repository to run actions locally
@@ -396,7 +438,7 @@ jobs:
           testpypi_published: ${{ needs.testPypi.result }}
           pypi_published: ${{ needs.pypi.result }}
           npmjs_published: ${{ needs.npmjs.result }}
-          status: ${{ job.status == 'success' && needs.release.result == 'success' && needs.mavenCentral.result != 'failure' && needs.javadocPublication.result != 'failure' && needs.testPypi.result != 'failure' && needs.pypi.result != 'failure' && needs.npmjs.result != 'failure' }}
+          status: ${{ job.status == 'success' && needs.release.result == 'success' && needs.mavenCentral.result != 'failure' && needs.javadocPublication.result != 'failure' && needs.testPypi.result != 'failure' && needs.pypi.result != 'failure' && needs.npmjs.result != 'failure' && needs.publish.result != 'failure' }}
           repo: ${{ github.repository }}
           run_id: ${{ github.run_id }}
           is_dummy_project: ${{ inputs.isDummyProject }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,67 @@ Notes:
 
 - `publishToBinaries`: Only if the binaries are delivered to customers - "binaries" is an AWS S3 bucket. The `ARTIFACTORY_DEPLOY_REPO`
   environment variable is required in the release Build Info.
+
+## Migrating from v6 to v7 (draft-first, `workflow_dispatch`)
+
+v7 introduces a **draft-first** release flow that fully complies with GitHub's Release Immutability feature. The release is kept as a draft
+until every downstream publication step succeeds, at which point it is atomically published (and becomes immutable). Failures leave the
+draft intact so you can fix the root cause and retry with the same version — no rebuild.
+
+### What changed
+
+| Area             | v6                                                                           | v7                                                                                 |
+|------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| Trigger          | `release: types: [published]`<br/>User publishes a release in the GitHub UI. | `workflow_dispatch` with `version` input<br/>User or CI runs the release workflow. |
+| Release creation | Before workflow execution.                                                   | Workflow creates or reuses the draft release.                                      |
+| Failure handling | Release and tag deleted (or kept since `v6.8.1`)                             | Draft saved; re-run the failed workflow to retry.                                  |
+
+### Migration Steps
+
+1. Update `.github/workflows/release.yml`:
+
+It was already possible to trigger v6 with `workflow_dispatch` and a `version` input, but the `release: published` trigger was the default
+and the `version` input was optional. For v7, the trigger is switched to `workflow_dispatch` and `version` is required.
+
+```yaml
+# Before (v6)
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  release:
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+```
+
+```yaml
+# After (v7)
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Full version including build number, e.g. 1.2.3.456'
+        required: true
+
+jobs:
+  release:
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
+    with:
+      version: ${{ inputs.version }}
+```
+
+Three changes: the `on:` block (drop `release: types: [published]`, make `version` required), the `with:` block (add `version` pass-through), and the `@v6` → `@v7` pin.
+
+2. How to trigger a release:
+
+- **UI**: Go to **Actions → Release → Run workflow**, enter the `version` (e.g. `1.2.3.456`).
+- **CLI**: `gh workflow run release.yml -f version=1.2.3.456`
+- **Retry**: Re-run the failed workflow from the GitHub Actions UI ("Re-run jobs").
+
+3. Attaching assets to the draft release:
+
+If your repo has workflows that attach assets (e.g. SBOMs, installers) to the GitHub release, those must run **before** v7 publishes the draft. Create the draft first, attach assets using the draft's `release-id`, then call v7 (which reuses the draft and publishes it atomically). See [`gh-action_sbom`](https://github.com/SonarSource/gh-action_sbom) for an example with SBOMs.
+
 - `isDummyProject`: The _dummy_ projects are treated differently regarding alerts and metrics. E.g.: in Datadog, the stats from dummy
   projects are excluded from some dashboards.
 
@@ -72,7 +133,7 @@ Since v6.8.1, when a release workflow fails (releasability checks, Artifactory p
 
 ### What happens on failure
 
-- The GitHub release stays published (visible in the Releases tab).
+- The GitHub release stays as a draft (visible in the Releases tab).
 - The Git tag stays in place.
 - JFrog/S3 artifacts **are** revoked (no broken artifacts are available to downstream consumers).
 - You will see a `::warning::` annotation in the Actions log and a Slack message with retry instructions.
@@ -80,11 +141,7 @@ Since v6.8.1, when a release workflow fails (releasability checks, Artifactory p
 ### Retrying without rebuilding
 
 1. Fix the root cause (e.g. merge the missing Jira fix-version, resolve the releasability check).
-2. Go to **Actions → Release → Run workflow** (or use `gh workflow run`).
-3. Fill in:
-   - `version` — the tag name (e.g. `1.2.3.456`), visible in the failed run or the Slack notification.
-   - `releaseId` — the GitHub release ID, also visible in the Slack notification or the failed run annotations.
-4. Run the workflow. No new build is needed.
+2. Re-run the failed workflow from the GitHub Actions UI ("Re-run jobs"). No new build is needed.
 
 ### Abandoning a failed release
 

--- a/main/release/utils/github.py
+++ b/main/release/utils/github.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import logging
+import requests
 
 from release.utils.dryrun import DryRunHelper
 from release.steps.ReleaseRequest import ReleaseRequest
@@ -110,7 +111,21 @@ class GitHub:
         return os.environ.get('INPUT_PUBLISH_TO_BINARIES', 'false').lower() == "true"
 
     def _get_release(self) -> dict | None:
-        return self.event.get("release", None)
+        # Retro-compat: the legacy `release:published` event embeds the full release object
+        # directly in the event payload, so no API call is needed. v7 uses `workflow_dispatch`
+        # which has no release in the payload — we fetch it by tag via the API instead.
+        if self.event.get("release") is not None:
+            return self.event["release"]
+        # workflow_dispatch path: fetch the draft (or published) release by tag via API
+        tag = os.environ.get("INPUT_VERSION")
+        if not tag:
+            return None
+        repo = self.event["repository"]["full_name"]
+        resp = requests.get(
+            f"https://api.github.com/repos/{repo}/releases/tags/{tag}",
+            headers={"Authorization": f"token {self.token}"},
+        )
+        return resp.json() if resp.ok else None
 
     def _get_repository(self) -> {}:
         return self.event["repository"]

--- a/main/tests/github_test.py
+++ b/main/tests/github_test.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch, mock_open, MagicMock
 import re
 import pytest
+import requests as real_requests
 
 from release.utils.github import GitHub, GitHubException, ALLOWED_GITHUB_ACTIONS
 
@@ -272,3 +273,119 @@ def test_no_release_no_dry_run(json_load_mock):
         release_request = github.get_release_request()
         assert release_request.branch == 'master'
         github.revoke_release()
+
+
+# ── _get_release() v7 path: release event (legacy v6 path) ──────────────────
+
+@patch.dict(os.environ, {"GITHUB_EVENT_NAME": "release", "GITHUB_TOKEN": "tok"}, clear=True)
+@patch(
+    "release.utils.github.json.load",
+    return_value={
+        "release": {"id": 1, "tag_name": "1.0.0.42"},
+        "repository": {"full_name": "org/project"},
+    },
+)
+def test_get_release_reads_from_event_on_release_event(mock_load):
+    with patch("release.utils.github.open", mock_open()):
+        github = GitHub()
+        release = github._get_release()
+        assert release == {"id": 1, "tag_name": "1.0.0.42"}
+
+
+# ── _get_release() v7 path: workflow_dispatch fetches via API ────────────────
+
+@patch.dict(
+    os.environ,
+    {"GITHUB_EVENT_NAME": "workflow_dispatch", "GITHUB_TOKEN": "tok", "INPUT_VERSION": "2.0.0.99"},
+    clear=True,
+)
+@patch(
+    "release.utils.github.json.load",
+    return_value={
+        "inputs": {"version": "2.0.0.99"},
+        "repository": {"full_name": "org/project", "default_branch": "master"},
+    },
+)
+def test_get_release_fetches_via_api_on_workflow_dispatch(mock_load):
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {"id": 99, "tag_name": "2.0.0.99", "draft": True}
+    with patch("release.utils.github.open", mock_open()):
+        with patch("release.utils.github.requests.get", return_value=mock_response) as mock_get:
+            github = GitHub()
+            release = github._get_release()
+            assert release == {"id": 99, "tag_name": "2.0.0.99", "draft": True}
+            mock_get.assert_called_once_with(
+                "https://api.github.com/repos/org/project/releases/tags/2.0.0.99",
+                headers={"Authorization": "token tok"},
+            )
+
+
+@patch.dict(
+    os.environ,
+    {"GITHUB_EVENT_NAME": "workflow_dispatch", "GITHUB_TOKEN": "tok"},
+    clear=True,
+)
+@patch(
+    "release.utils.github.json.load",
+    return_value={
+        "inputs": {"version": ""},
+        "repository": {"full_name": "org/project", "default_branch": "master"},
+    },
+)
+def test_get_release_returns_none_when_input_version_missing(mock_load):
+    with patch("release.utils.github.open", mock_open()):
+        github = GitHub()
+        release = github._get_release()
+        assert release is None
+
+
+@patch.dict(
+    os.environ,
+    {"GITHUB_EVENT_NAME": "workflow_dispatch", "GITHUB_TOKEN": "tok", "INPUT_VERSION": "3.0.0.1"},
+    clear=True,
+)
+@patch(
+    "release.utils.github.json.load",
+    return_value={
+        "inputs": {"version": "3.0.0.1"},
+        "repository": {"full_name": "org/project", "default_branch": "master"},
+    },
+)
+def test_get_release_returns_none_on_api_404(mock_load):
+    mock_response = MagicMock()
+    mock_response.ok = False
+    with patch("release.utils.github.open", mock_open()):
+        with patch("release.utils.github.requests.get", return_value=mock_response):
+            github = GitHub()
+            release = github._get_release()
+            assert release is None
+
+
+# ── revoke_release() remains a no-op in all paths (carry-over from v6.8.1) ──
+
+@patch.dict(
+    os.environ,
+    {"GITHUB_EVENT_NAME": "workflow_dispatch", "GITHUB_TOKEN": "tok", "INPUT_VERSION": "1.0.0.42"},
+    clear=True,
+)
+@patch(
+    "release.utils.github.json.load",
+    return_value={
+        "inputs": {"version": "1.0.0.42"},
+        "repository": {"full_name": "org/project", "default_branch": "master"},
+    },
+)
+def test_revoke_release_is_noop_on_workflow_dispatch_path(mock_load):
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {"id": 7, "tag_name": "1.0.0.42"}
+    with patch("release.utils.github.open", mock_open()):
+        with patch("release.utils.github.requests.get", return_value=mock_response):
+            with patch("release.utils.github.requests.delete") as mock_delete:
+                with patch("release.utils.github.requests.patch") as mock_patch:
+                    github = GitHub()
+                    # revoke_release must complete without raising and without making HTTP mutations
+                    github.revoke_release()
+                    mock_delete.assert_not_called()
+                    mock_patch.assert_not_called()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,4 +22,9 @@ git checkout "${original_ref}" -- .
 git commit -m "chore: revert release commits" -a
 git push origin "$version"
 git push origin "${branch}"
-gh release create "$version" -t "$version" --target "$(git show -s --pretty=format:'%H' "$version")" --verify-tag --generate-notes
+# Trigger the release workflow via workflow_dispatch.
+# The reusable workflow owns draft creation, checks, promotion, and publication.
+GITHUB_REPO="${GITHUB_REPO:-SonarSource/gh-action_release}"
+gh workflow run release.yml \
+  --repo "$GITHUB_REPO" \
+  -f version="$version"


### PR DESCRIPTION
## Summary

- Implements Phase 2 of the GitHub Release Immutability migration ([BUILD-11106](https://sonarsource.atlassian.net/browse/BUILD-11106), Epic [BUILD-10870](https://sonarsource.atlassian.net/browse/BUILD-10870))
- Reusable workflow now creates a draft release first, runs all checks and artifact promotions while the release is still mutable, then publishes atomically via a `finalize` job
- No release ever becomes public until every downstream step succeeds; failures leave the draft intact for retry (same version, no rebuild)
- SBOM attachment is **not** handled here — consumers who need SBOM call `gh-action_sbom` directly with a `release-id` pointing at the draft (Pattern B, see [gh-action_sbom#79](https://github.com/SonarSource/gh-action_sbom/pull/79))

### Key changes

- `version` input is now **required** (breaking change → ships as v7)
- New `Ensure draft release exists` step (idempotent: reuses existing draft on retry; fails fast if a *published* release already exists for that tag)
- New `finalize` job: `gh release edit --draft=false` runs only when all jobs succeed or are skipped
- `_get_release()` fetches release via GitHub API for `workflow_dispatch` events (`INPUT_VERSION` env var)
- `scripts/release.sh` dogfoods `workflow_dispatch` instead of `gh release create`
- README: complete v6 → v7 consumer migration guide

## Test results ✅

All tests run on [SonarSource/sonar-dummy](https://github.com/SonarSource/sonar-dummy) with release immutability enabled, pointing at this branch.

| # | Scenario | Run | Result |
|---|---|---|---|
| **T7** | Dry run (`dryRun=true`) | [#24987609054](https://github.com/SonarSource/sonar-dummy/actions/runs/24987609054) | ✅ All publication jobs skipped, no draft created, run green |
| **T2** | Releasability failure (fake version `15.0.2.99999`) | [#24987656961](https://github.com/SonarSource/sonar-dummy/actions/runs/24987656961) | ✅ Draft kept, warning logged with `releaseId`, `finalize` skipped |
| **T3** | Retry with `releaseId` from T2 | [#24987734424](https://github.com/SonarSource/sonar-dummy/actions/runs/24987734424) | ✅ "Reusing existing draft release 15.0.2.99999" — same draft reused |
| **T6** | Pre-existing *published* release for same version | [#24987831514](https://github.com/SonarSource/sonar-dummy/actions/runs/24987831514) | ✅ Fast fail: "Release already exists and is NOT a draft. Aborting." |
| **T1** | Happy path `15.0.2.10129` | [#24987866968](https://github.com/SonarSource/sonar-dummy/actions/runs/24987866968) | ✅ Draft created → releasability passed → javadoc published → finalize ran → `draft: false` confirmed |

SonarQube Cloud quality gate: **passed** — 0 new issues, 100% coverage on new code.

## Test plan (remaining before promoting @v7 tag)

- [x] Stage A (integration on sonar-dummy): all 5 scenarios above — **done**
- [x] Stage B: unit tests — 21 tests green, 100% coverage on new code (SonarCloud confirms)
- [ ] Stage C: pilot on one real consumer repo before broad rollout

[BUILD-11106]: https://sonarsource.atlassian.net/browse/BUILD-11106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-10870]: https://sonarsource.atlassian.net/browse/BUILD-10870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ