### PR TITLE
BUILD-11106 Simplify self-reference release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,6 @@ been performed based on the provided inputs defined in `with:` section.
 
 ### Releasing
 
-⚠️ At the moment, the release requires an exception in the GitHub ruleset:
-see [xtranet/Platform/Branch Protection Organization Ruleset - GitHub#Exception Record](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/4008509456/Branch+Protection+Organization+Ruleset+-+GitHub#Exception-Record)
-
 To create a release run the [Release workflow](https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml). The workflow
 will create the GitHub Release.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ To create a release run the [Release workflow](https://github.com/SonarSource/gh
 To update the v-branch run the [Update v-branch workflow](https://github.com/SonarSource/gh-action_release/actions/workflows/update-v-branch.yml). The workflow will update the v-branch to the specified tag.
 
 ## Explanation
-Due to the issue with GitHub Reusable Workflows referencing files in the same repository, the release process needs to create 2 commits to be able to have a tag referencing all worflows with the same version.
+Due to the issue with GitHub Reusable Workflows referencing files in the same repository, the release process needs to pin the self-references to a stable SHA before tagging. This is done in a detached commit so the branch is never modified.
 
 #### Tag and Release
 
@@ -18,20 +18,18 @@ scripts/release.sh <branch> <version>
 
 This script will:
 
-1. commit references the future tag
-2. commit references the previous commit
-3. tag this second commit
-4. revert previous commits
+1. capture the branch tip SHA (`original_sha`)
+2. in detached HEAD, replace all `@<branch>` and `ref: ${{ github.ref }}` self-references with `@<original_sha>`
+3. commit and tag that detached commit as `<version>`
+4. push only the tag (the branch is left untouched)
 5. create a Release on GitHub
 
 Example:
 
 ```
 $ scripts/release.sh branch-2 2.0.0
-$ git log --graph --pretty="%H %s %d" branch-2 -3 --reverse
-* 1c42d553f38c91d92aaff793a67d48d62255f9be chore: update self-references to 2.0.0
-* 2082aca0c8aa7cb64320b3713391d3d1056aaec6 chore: update self-references to 1c42d553f38c91d92aaff793a67d48d62255f9be  (tag: 2.0.0)
-* 0000554720dc90f987a86a43531b8595f27ea53e chore: update self-references to branch-2  (origin/pull/158, origin/branch-2)
+$ git show -s --pretty="%H %s %D" 2.0.0
+2082aca0c8aa7cb64320b3713391d3d1056aaec6 chore: release 2.0.0 (tag: 2.0.0)
 ```
 
 #### Update the v* Branch

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,22 +9,21 @@ version=$2
 git fetch --tags --all
 git checkout "${branch}"
 git pull origin "${branch}"
-original_ref=$(git rev-parse HEAD)
-git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${branch},\1${version},g"
-git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s/ref: \${{ github.ref }}/ref: ${version}/g"
-git commit -m "chore: prepare ${version} for future reference" -a
-next_ref=$(git show -s --pretty=format:'%H')
-git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${version},\1${next_ref},g"
-git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | xargs sed -i "s/ref: ${version}/ref: ${next_ref}/g"
-git commit -m "chore: release ${version} reference" -a
+original_sha=$(git rev-parse HEAD)
+
+# Create a detached release commit with SHA-pinned self-references (branch untouched)
+git checkout --detach HEAD
+git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | \
+  xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${branch},\1${original_sha},g"
+git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | \
+  xargs sed -i "s/ref: \${{ github.ref }}/ref: ${original_sha}/g"
+git commit -m "chore: release ${version}" -a
 git tag "$version"
-git checkout "${original_ref}" -- .
-git commit -m "chore: revert release commits" -a
+git checkout "${branch}"
+
 git push origin "$version"
-git push origin "${branch}"
-# Trigger the release workflow via workflow_dispatch.
-# The reusable workflow owns draft creation, checks, promotion, and publication.
-GITHUB_REPO="${GITHUB_REPO:-SonarSource/gh-action_release}"
-gh workflow run release.yml \
-  --repo "$GITHUB_REPO" \
-  -f version="$version"
+gh release create "$version" \
+  -t "$version" \
+  --target "$(git show -s --pretty=format:'%H' "$version")" \
+  --verify-tag \
+  --generate-notes


### PR DESCRIPTION
## Summary

- Replaces the two-commit dance (prepare → release-reference → revert, pushing 3 commits to the branch) with a **single detached commit**: pins `@<branch>` and `ref: ${{ github.ref }}` self-references directly to the branch-tip SHA, tags the detached commit, and pushes only the tag.
- The branch is never modified, so **the GitHub ruleset exception is no longer needed**.
- Restores `gh release create` instead of the broken `gh workflow run release.yml` that caused a self-triggering loop.
- Updates README and RELEASE.md accordingly.

## Test plan

- [ ] Trigger the [Release workflow](https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml) on a test version and verify the tag is created with a single detached commit, the branch history is clean, and the GitHub Release is created.