### PR TITLE
BUILD-11271 Add option to require pre-created draft release

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -37,6 +37,7 @@ jobs:
     with:
       version: "0.0.0.0"
       dryRun: true
+      createDraftRelease: true
       publishToBinaries: false
       binariesS3Bucket: test-bucket
       slackChannel: ""

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,11 @@ on:
         description: Flag to enable the dry-run execution
         default: false
         required: false
+      createDraftRelease:
+        type: boolean
+        description: Create the draft release when it does not already exist
+        default: true
+        required: false
       publishToBinaries:
         type: boolean
         description: Flag to enable the publication to binaries
@@ -158,12 +163,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
+          CREATE_DRAFT_RELEASE: ${{ inputs.createDraftRelease }}
         run: |
           set -euo pipefail
-          if gh release view "$VERSION" --repo "${{ github.repository }}" --json id,isDraft -q '.isDraft' 2>/dev/null | grep -q true; then
-            echo "Reusing existing draft release $VERSION"
-          elif gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "::error::Release $VERSION already exists and is NOT a draft. Aborting to avoid duplicate publish."
+          if release_details="$(gh release view "$VERSION" --repo "${{ github.repository }}" --json id,isDraft --jq '[.id, .isDraft] | @tsv' 2>/dev/null)"; then
+            read -r release_id release_is_draft <<< "$release_details"
+            if [[ "$release_is_draft" == "true" ]]; then
+              echo "Reusing existing draft release $VERSION"
+            else
+              echo "::error::Release $VERSION already exists and is NOT a draft. Aborting to avoid duplicate publish."
+              exit 1
+            fi
+          elif [[ "$CREATE_DRAFT_RELEASE" == "false" ]]; then
+            echo "::error::Draft release $VERSION does not exist and createDraftRelease=false. Create the draft release before running this workflow."
             exit 1
           else
             gh release create "$VERSION" \
@@ -171,8 +183,8 @@ jobs:
               --draft --generate-notes \
               --target "$GITHUB_SHA"
             echo "Created draft release $VERSION"
+            release_id=$(gh release view "$VERSION" --repo "${{ github.repository }}" --json id -q '.id')
           fi
-          release_id=$(gh release view "$VERSION" --repo "${{ github.repository }}" --json id -q '.id')
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS Credentials

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
       slackChannel: build # define the Slack channel to use for notifications
       artifactoryRoleSuffix: promoter # define the Artifactory promoter role suffix
       dryRun: false # perform a dry run execution
+      createDraftRelease: true # create the draft release if it does not already exist
       pushToDatadog: true # push results to Datadog for monitoring
       isDummyProject: false # set to true if this is a dummy project (e.g. sonar-dummy)
 ```
@@ -108,6 +109,8 @@ Three changes: the `on:` block (drop `release: types: [published]`, make `versio
 3. Attaching assets to the draft release:
 
 If your repo has workflows that attach assets (e.g. SBOMs, installers) to the GitHub release, those must run **before** v7 publishes the draft. Create the draft first, attach assets using the draft's `release-id`, then call v7 (which reuses the draft and publishes it atomically). See [`gh-action_sbom`](https://github.com/SonarSource/gh-action_sbom) for an example with SBOMs.
+
+- `createDraftRelease`: To require a pre-created draft release set `createDraftRelease: false`. If the draft release for `version` does not already exist, the workflow fails.
 
 - `isDummyProject`: The _dummy_ projects are treated differently regarding alerts and metrics. E.g.: in Datadog, the stats from dummy
   projects are excluded from some dashboards.


### PR DESCRIPTION
Adds createDraftRelease to the reusable release workflow.

When set to false, the workflow now fails if the draft release does not already exist, instead of creating it automatically. The default remains true, preserving existing behavior.

Part of [BUILD-11271](https://sonarsource.atlassian.net/browse/BUILD-11271)

_Assisted by Codex._

[BUILD-11271]: https://sonarsource.atlassian.net/browse/BUILD-11271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ