### PR TITLE
BUILD-11274 Add GitHub summary with release notes and next steps

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -166,8 +166,9 @@ jobs:
           CREATE_DRAFT_RELEASE: ${{ inputs.createDraftRelease }}
         run: |
           set -euo pipefail
-          if release_details="$(gh release view "$VERSION" --repo "${{ github.repository }}" --json id,isDraft --jq '[.id, .isDraft] | @tsv' 2>/dev/null)"; then
-            read -r release_id release_is_draft <<< "$release_details"
+          if release_details="$(gh release view "$VERSION" --repo "${{ github.repository }}" --json id,isDraft 2>/dev/null)"; then
+            release_id=$(jq -r '.id' <<< "$release_details")
+            release_is_draft=$(jq -r '.isDraft' <<< "$release_details")
             if [[ "$release_is_draft" == "true" ]]; then
               echo "Reusing existing draft release $VERSION"
             else

--- a/README.md
+++ b/README.md
@@ -256,13 +256,15 @@ been performed based on the provided inputs defined in `with:` section.
 ### Releasing
 
 To create a release run the [Release workflow](https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml). The workflow
-will create the GitHub Release.
+will create a **draft** GitHub Release, then post a summary with the release URL, generated notes (with a template to fill in),
+and next steps: review and complete the notes, publish the draft, and communicate on
+[#ops-platform-releases](https://sonarsource.enterprise.slack.com/archives/C0A6RL3L9BP) using the `/platform-comms` skill.
 
 To update the v-branch run
 the [Update v-branch workflow](https://github.com/SonarSource/gh-action_release/actions/workflows/update-v-branch.yml). The workflow will
 update the v-branch to the specified tag.
 
-For more deails see [RELEASE.md](./RELEASE.md)
+For more details see [RELEASE.md](./RELEASE.md)
 
 ## References
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ Due to the issue with GitHub Reusable Workflows referencing files in the same re
 This is available on GitHub: https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml
 
 ```bash
-scripts/release.sh <branch> <version>
+scripts/release.sh <branch> <version> [draft=true]
 ```
 
 This script will:
@@ -22,15 +22,14 @@ This script will:
 2. in detached HEAD, replace all `@<branch>` and `ref: ${{ github.ref }}` self-references with `@<original_sha>`
 3. commit and tag that detached commit as `<version>`
 4. push only the tag (the branch is left untouched)
-5. create a Release on GitHub
+5. create a **draft** Release on GitHub (default) with auto-generated notes
+6. post a summary to the workflow run with the release URL, release notes, and next steps
 
-Example:
+After the workflow completes:
 
-```
-$ scripts/release.sh branch-2 2.0.0
-$ git show -s --pretty="%H %s %D" 2.0.0
-2082aca0c8aa7cb64320b3713391d3d1056aaec6 chore: release 2.0.0 (tag: 2.0.0)
-```
+1. **Review and complete the release notes** — the summary includes a template with sections (New Features, Improvements, Bug Fixes, Documentation); fill in and remove empty sections
+2. **Publish the draft release** once the notes are finalized
+3. **Communicate the release** on [#ops-platform-releases](https://sonarsource.enterprise.slack.com/archives/C0A6RL3L9BP) using the `/platform-comms` skill
 
 #### Update the v* Branch
 
@@ -38,12 +37,4 @@ Available as a workflow at: https://github.com/SonarSource/gh-action_release/act
 
 ```bash
 scripts/updatevbranch.sh <version>
-```
-
-Example:
-
-```
-$ scripts/updatevbranch.sh 2.0.0
-$ git show -s --pretty=format:'%H%d' 2.0.0
-2082aca0c8aa7cb64320b3713391d3d1056aaec6 (tag: 2.0.0, origin/v2)
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ Due to the issue with GitHub Reusable Workflows referencing files in the same re
 This is available on GitHub: https://github.com/SonarSource/gh-action_release/actions/workflows/release.yml
 
 ```bash
-scripts/release.sh <branch> <version> [draft=true]
+scripts/release.sh <branch> <version> [true|false]
 ```
 
 This script will:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Release a new version of the action
-# Usage: scripts/release.sh <branch> <version>
+# Usage: scripts/release.sh <branch> <version> [draft=true]
 set -xeuo pipefail
 
+: "${GITHUB_STEP_SUMMARY:?}"
 type git gh >/dev/null
 branch=$1
 version=$2
@@ -21,9 +22,66 @@ git commit -m "chore: release ${version}" -a
 git tag "$version"
 git checkout "${branch}"
 
+draft=${3:-true}
+if [[ "$draft" == "true" ]]; then
+  draft_flag="--draft"
+else
+  draft_flag=""
+fi
+
 git push origin "$version"
+# shellcheck disable=SC2086
 gh release create "$version" \
   -t "$version" \
   --target "$(git show -s --pretty=format:'%H' "$version")" \
   --verify-tag \
-  --generate-notes
+  --generate-notes \
+  ${draft_flag}
+
+release_json=$(gh release view "$version" --json url,body)
+release_url=$(jq -r '.url' <<< "$release_json")
+release_notes=$(jq -r '.body' <<< "$release_json")
+
+publish_step=""
+if [[ "$draft" == "true" ]]; then
+  publish_step="1. **Publish the draft release** once the notes are finalized"
+fi
+
+cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+## Release $version
+
+URL: $release_url
+
+<details><summary>Release Notes</summary>
+
+${release_notes}
+
+</details>
+
+---
+
+## Next Steps
+
+1. **Review and complete the release notes** at $release_url
+    - Replace \`## What's Changed\` line with the following:
+    \`\`\`
+    ## What's Changed
+
+    ### New Features
+
+    ### Improvements
+
+    ### Bug Fixes
+
+    ### Documentation
+    \`\`\`
+    - Fill in the sections: New Features, Improvements, Bug Fixes, Documentation
+    - Add usage examples or references if applicable
+    - Remove empty sections
+${publish_step}
+1. **Communicate the release** on [#ops-platform-releases](https://sonarsource.enterprise.slack.com/archives/C0A6RL3L9BP)
+    using the \`/platform-comms\` skill from engxp-squad plugin:
+    \`\`\`
+    /engxp-squad:platform-comms https://github.com/SonarSource/gh-action_release/releases/tag/$version
+    \`\`\`
+EOF

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Release a new version of the action
-# Usage: scripts/release.sh <branch> <version> [draft=true]
+# Usage: scripts/release.sh <branch> <version> [true|false]
 set -xeuo pipefail
 
 : "${GITHUB_STEP_SUMMARY:?}"
@@ -68,12 +68,16 @@ ${release_notes}
     ## What's Changed
 
     ### New Features
+    - _Curated highlights from release notes: new features, important new options_
 
     ### Improvements
+    - _Curated highlights from release notes: improvement and upgrades_
 
     ### Bug Fixes
+    - _Curated highlights from release notes_
 
     ### Documentation
+    - _Curated highlights from release notes_
     \`\`\`
     - Fill in the sections: New Features, Improvements, Bug Fixes, Documentation
     - Add usage examples or references if applicable


### PR DESCRIPTION
## Summary

- Creates release as **draft by default**
- Posts a workflow step summary with: release URL, auto-generated notes injected with a fill-in template (New Features / Improvements / Bug Fixes / Documentation), and next steps (review notes → publish draft → communicate via `/platform-comms`)
- Refactors `gh release view` to a single JSON call + local `jq` parsing in both `scripts/release.sh` and `.github/workflows/main.yaml`
- Updates `RELEASE.md` and `README.md` to reflect the draft-first flow and post-release steps

Fixes https://sonarsource.atlassian.net/browse/BUILD-11274

## Test plan

- [x] Run the Release workflow on a test branch/version with `draft=true` (default) and verify the step summary appears with the expected template and next-steps
https://github.com/SonarSource/gh-action_release/actions/runs/25506362602
<img width="1425" height="1244" alt="image" src="https://github.com/user-attachments/assets/31643a4e-5ef5-44c6-b9b6-5ceb3843104a" />
