### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/it-test-download-build.yml
+++ b/.github/workflows/it-test-download-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   it-tests-default-values:
     name: IT Test - use default inputs values should generate expected output"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write
@@ -36,7 +36,7 @@ jobs:
 
   it-tests-use-flat-download-true:
     name: IT Test - use flat-download=true should generate expected output"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write
@@ -64,7 +64,7 @@ jobs:
 
   it-tests:
       name: "All IT Tests have to pass (download-build)"
-      runs-on: github-ubuntu-latest-s
+      runs-on: warp-custom-ubuntu-24-04
       if: always()
       needs:
         # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   release:
     name: Test action
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (Necessary to access local action)
       - uses: ./main

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -39,7 +39,7 @@ name: Javadoc publication
 jobs:
   javadoc-publication:
     name: Publish javadoc
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,7 +119,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC
@@ -402,7 +402,7 @@ jobs:
 
   datadog:
     name: Push results to datadog
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     environment: ${{ inputs.githubEnvironment }}
     needs:
       - release

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -35,7 +35,7 @@ name: Maven Central
 jobs:
   maven-central:
     name: Push to maven Central
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC

--- a/.github/workflows/npmjs.yaml
+++ b/.github/workflows/npmjs.yaml
@@ -49,7 +49,7 @@ name: NpmJS
 jobs:
   publish-to-npm:
     name: Publish to npmjs
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -44,7 +44,7 @@ name: PyPI
 jobs:
   pypi:
     name: Publish to PyPI
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release ${{ inputs.version }}
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test-javadoc-logic.yml
+++ b/.github/workflows/test-javadoc-logic.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test Javadoc Script
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -8,7 +8,7 @@
 
     jobs:
       build:
-        runs-on: github-ubuntu-latest-s
+        runs-on: warp-custom-ubuntu-24-04
         name: Build and run shadow scans
         permissions:
           id-token: write

--- a/.github/workflows/update-v-branch.yml
+++ b/.github/workflows/update-v-branch.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-v-branch:
     name: Update v* branch to ${{ inputs.tag }}
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/build.yml`
- `.github/workflows/it-test-download-build.yml`
- `.github/workflows/it-test.yml`
- `.github/workflows/javadoc-publication.yaml`
- `.github/workflows/main.yaml`
- `.github/workflows/maven-central.yaml`
- `.github/workflows/npmjs.yaml`
- `.github/workflows/pre-commit.yml`
- `.github/workflows/pypi.yaml`
- `.github/workflows/release.yml`
- `.github/workflows/test-javadoc-logic.yml`
- `.github/workflows/unified-dogfooding.yml`
- `.github/workflows/update-v-branch.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
