### PR TITLE
BUILD-11469 Add manual Maven Central re-sync script and name CI deployments

### DIFF
--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -86,6 +86,7 @@ jobs:
           auto-publish: "true"
         env:
           CENTRAL_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).central_token }}
+          DEPLOYMENT_NAME: ${{ inputs.projectName != '' && inputs.projectName || github.event.repository.name }}-${{ steps.get_version.outputs.build }}
       - name: Notify on failure
         if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
         uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ gh release delete <tag> --cleanup-tag --yes --repo <org/repo>
 
 > **Note:** After deleting the release, the tag name is protected by GitHub's resurrection protection — it cannot be reused for a new release. A new build (and new tag) is required.
 
+### Manual Maven Central re-sync
+
+If `mavenCentralSync` was disabled at release time and the artifacts need to be pushed to Maven Central after the fact, run `scripts/manual-maven-central-sync.sh <build-name> <build-number>` locally — it mirrors the CI flow (JFrog download + Central Portal upload) without re-running the full release. See [Manual Sync — Maven Central](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/2401697818) for the full procedure and prerequisites.
+
 ## Releasability check
 
 To perform a releasability check for a given version without performing an actual release, run

--- a/maven-central-sync/maven-central-publish.sh
+++ b/maven-central-sync/maven-central-publish.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 LOCAL_REPO_DIR="$1"
 CENTRAL_URL="$2"
 AUTO_PUBLISH="$3"
+DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-central-bundle}"
 
 # Validate required environment variables
 if [ -z "${CENTRAL_TOKEN:-}" ]; then
@@ -15,6 +16,7 @@ fi
 echo "Starting Central Portal publishing..."
 echo "Repository: $LOCAL_REPO_DIR"
 echo "Auto-publish: $AUTO_PUBLISH"
+echo "Deployment name: $DEPLOYMENT_NAME"
 
 # Validate that we have artifacts in the repository directory
 if [ ! -d "$LOCAL_REPO_DIR" ]; then
@@ -62,11 +64,14 @@ echo "Publishing type: $PUBLISHING_TYPE"
 
 echo "Uploading to Central Portal..."
 
+ENCODED_NAME=$(jq -rn --arg s "$DEPLOYMENT_NAME" '$s|@uri')
+UPLOAD_URL="$CENTRAL_URL/api/v1/publisher/upload?publishingType=$PUBLISHING_TYPE&name=$ENCODED_NAME"
+
 UPLOAD_RESPONSE=$(curl -s -w "HTTPSTATUS:%{http_code}" \
     -X POST \
     -H "$AUTH_HEADER" \
     -F "bundle=@$BUNDLE_FILE" \
-    "$CENTRAL_URL/api/v1/publisher/upload?publishingType=$PUBLISHING_TYPE")
+    "$UPLOAD_URL")
 
 HTTP_STATUS=$(echo "$UPLOAD_RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 RESPONSE_BODY="${UPLOAD_RESPONSE%HTTPSTATUS:*}"

--- a/scripts/manual-maven-central-sync.sh
+++ b/scripts/manual-maven-central-sync.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# Manual re-sync of a SonarSource build to Maven Central via the Central Portal.
+#
+# Use this when the `mavenCentral` job in `gh-action_release/.github/workflows/main.yaml` was skipped at release time and you need to push
+# the already-built artifacts to Maven Central after the fact
+#
+# This script mirrors what `.github/workflows/maven-central.yaml` does in CI:
+#   1. Download the build's artifacts + checksums from JFrog (sonarsource-public-releases) into a temp dir.
+#   2. Bundle and upload them to the Central Portal via the existing `maven-central-sync/maven-central-publish.sh` script, then poll for
+#      validation/publication.
+#
+# Prerequisites:
+#   - `jfrog` (v1) or `jf` (v2) CLI configured against repox.jfrog.io with read access to the build's `sonarsource-public-releases` repo
+#   and build-info.
+#   - `vault` CLI logged in to https://vault.sonar.build:8200
+#   - `zip`, `curl`, `find`, `jq`.
+#
+# Usage:
+#   scripts/manual-maven-central-sync.sh <build-name> <build-number> [project-name]
+#
+# Arguments:
+#   <build-name>     Repository / build name as registered in Artifactory build-info (e.g. `sonar-dotnet-enterprise`).
+#                    Used both for the JFrog build lookup and as the default project name.
+#   <build-number>   Build number = 4th dot-segment of the version. For `10.26.0.140279` the build number is `140279`.
+#   [project-name]   Optional override of the JFrog project name when it differs from the build name.
+#                    Required for sonar-enterprise (use `sonar-enterprise-sqcb`).
+#
+# Environment overrides (rarely needed):
+#   REMOTE_REPO      JFrog repo to download from (default: sonarsource-public-releases)
+#   FILTER           Path prefix under REMOTE_REPO to constrain the download (default: `org/sonarsource`).
+#                    Restricts the download to SonarSource Maven artifacts and drops non-Maven payloads (e.g. `.nupkg`) that Central
+#                    Portal rejects when they end up at the zip root. Set to empty (FILTER=) to download every file in the build.
+#   EXCLUSIONS       Passed verbatim to `jfrog rt download --exclusions` (default: `-`, i.e. no exclusions). Use to filter out a
+#                    specific path pattern, e.g. EXCLUSIONS='*.nupkg;*.snupkg'.
+#   CENTRAL_URL      Central Portal URL (default: https://central.sonatype.com)
+#   AUTO_PUBLISH     "true" to auto-publish, "false" to stop at VALIDATED (default: true)
+#   DEPLOYMENT_NAME  Name shown for the deployment on Central Portal (default: `<project-name>-<build-number>`).
+#   KEEP_WORK_DIR    Force-keep the temp work directory after the script exits (default: `true` on failure, `false` on success).
+#   JFROG_CLI        Force `jfrog` or `jf` CLI binary; auto-detected otherwise.
+#
+# Examples:
+#   # PREQ-6069 — sync 10.26.0.140279 then 10.27.0.140913 for sonar-dotnet-enterprise:
+#   scripts/manual-maven-central-sync.sh sonar-dotnet-enterprise 140279
+#   scripts/manual-maven-central-sync.sh sonar-dotnet-enterprise 140913
+#
+#   # sonar-enterprise (build name differs from project name):
+#   scripts/manual-maven-central-sync.sh sonar-enterprise 12345 sonar-enterprise-sqcb
+
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+    sed -n '2,/^set -euo/p' "$0" | sed -e 's/^# \{0,1\}//' -e '$d'
+    exit 0
+fi
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+    echo "Usage: $0 <build-name> <build-number> [project-name]" >&2
+    echo "Run '$0 --help' for details." >&2
+    exit 2
+fi
+
+BUILD_NAME="$1"
+BUILD_NUMBER="$2"
+PROJECT_NAME="${3:-$BUILD_NAME}"
+
+REMOTE_REPO="${REMOTE_REPO:-sonarsource-public-releases}"
+FILTER="${FILTER-org/sonarsource}"
+EXCLUSIONS="${EXCLUSIONS:--}"
+CENTRAL_URL="${CENTRAL_URL:-https://central.sonatype.com}"
+AUTO_PUBLISH="${AUTO_PUBLISH:-true}"
+DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-${PROJECT_NAME}-${BUILD_NUMBER}}"
+export DEPLOYMENT_NAME
+
+DOWNLOAD_TARGET="$REMOTE_REPO"
+if [[ -n "$FILTER" ]]; then
+    DOWNLOAD_TARGET="${REMOTE_REPO}/${FILTER}/"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PUBLISH_SCRIPT="$REPO_ROOT/maven-central-sync/maven-central-publish.sh"
+
+# Detect JFrog CLI (v2 `jf` or legacy `jfrog`).
+if [[ -z "${JFROG_CLI:-}" ]]; then
+    if command -v jfrog >/dev/null 2>&1; then
+        JFROG_CLI=jfrog
+    elif command -v jf >/dev/null 2>&1; then
+        JFROG_CLI=jf
+    else
+        echo "ERROR: neither 'jfrog' nor 'jf' CLI is on PATH" >&2
+        exit 1
+    fi
+fi
+
+# Resolve Central Portal token from Vault.
+CENTRAL_TOKEN="$(vault kv get -field=token development/kv/ossrh)"
+if [[ -z "$CENTRAL_TOKEN" ]]; then
+    echo "ERROR: empty CENTRAL_TOKEN — check 'vault login' and the secret path" >&2
+    exit 1
+fi
+export CENTRAL_TOKEN
+
+WORK_DIR="$(mktemp -d -t manual-mc-sync-XXXXXX)"
+LOCAL_REPO_DIR="$WORK_DIR/repo"
+mkdir -p "$LOCAL_REPO_DIR"
+
+cleanup() {
+    local rc=$?
+    if [[ $rc -ne 0 || "${KEEP_WORK_DIR:-false}" == "true" ]]; then
+        echo "Leaving $WORK_DIR for inspection (exit=$rc, KEEP_WORK_DIR=${KEEP_WORK_DIR:-false})"
+    else
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+echo "=================================================================="
+echo "  Build name      : $BUILD_NAME"
+echo "  Build number    : $BUILD_NUMBER"
+echo "  Project name    : $PROJECT_NAME"
+echo "  Remote repo     : $REMOTE_REPO"
+echo "  Filter          : ${FILTER:-<none>}"
+echo "  Exclusions      : $EXCLUSIONS"
+echo "  Download target : $DOWNLOAD_TARGET"
+echo "  Central URL     : $CENTRAL_URL"
+echo "  Auto-publish    : $AUTO_PUBLISH"
+echo "  Deployment name : $DEPLOYMENT_NAME"
+echo "  Work dir        : $LOCAL_REPO_DIR"
+echo "  JFrog CLI       : $JFROG_CLI"
+echo "=================================================================="
+
+echo "Downloading build artifacts from JFrog..."
+(
+    cd "$LOCAL_REPO_DIR"
+    "$JFROG_CLI" rt download --fail-no-op --exclusions "${EXCLUSIONS}" \
+        --build "${PROJECT_NAME}/${BUILD_NUMBER}" \
+        "${DOWNLOAD_TARGET}"
+)
+
+echo "Downloading checksums (md5/sha1/sha256) for every artifact..."
+# Note: `{{}}` is intentional — find substitutes the inner `{}` with the file
+# path and leaves the outer braces in place, so `jfrog rt curl` sees two
+# URL `{...}` expansions and the `#1.#2` output template resolves correctly
+# (#1 = path, #2 = md5|sha1|sha256). With a single `{}` curl writes the
+# literal string `#2` into the working directory.
+(
+    cd "$LOCAL_REPO_DIR"
+    find . -type f \
+        -not \( -name "*.asc" -or -name "*.md5" -or -name "*.sha1" -or -name "*.sha256" \) \
+        -exec "$JFROG_CLI" rt curl "${REMOTE_REPO}/{{}}.{md5,sha1,sha256}" --output "#1.#2" \;
+)
+
+# Sanity check 1: there must be at least one Maven-shaped artifact.
+if ! find "$LOCAL_REPO_DIR" -type f \( -name "*.jar" -o -name "*.war" -o -name "*.ear" -o -name "*.pom" \) | grep -q .; then
+    echo "ERROR: no Maven artifacts (jar/war/ear/pom) found under $LOCAL_REPO_DIR" >&2
+    echo "       Either the build has no Java payload (nothing to push to Maven Central)" >&2
+    echo "       or the JFrog download did not return what was expected." >&2
+    exit 1
+fi
+
+# Sanity check 2: nothing must be present directly at the bundle root.
+# Central Portal rejects bundles containing files at "./" — every artifact
+# must live under a groupId/artifactId/version/ path.
+if find "$LOCAL_REPO_DIR" -mindepth 1 -maxdepth 1 -type f | grep -q .; then
+    echo "ERROR: files found at the bundle root — Central Portal will reject this:" >&2
+    find "$LOCAL_REPO_DIR" -mindepth 1 -maxdepth 1 -type f | while IFS= read -r f; do
+        echo "       $f" >&2
+    done
+    echo "       Restrict the download to the Maven path prefix with FILTER, e.g." >&2
+    echo "       FILTER=org/sonarsource $0 $*" >&2
+    exit 1
+fi
+
+echo "Downloaded layout (top 3 levels):"
+( cd "$LOCAL_REPO_DIR" && find . -mindepth 1 -maxdepth 3 -type d | sort )
+
+echo "Publishing to Central Portal..."
+"$PUBLISH_SCRIPT" "$LOCAL_REPO_DIR" "$CENTRAL_URL" "$AUTO_PUBLISH"
+
+echo "Manual Maven Central sync completed for ${BUILD_NAME}/${BUILD_NUMBER}."


### PR DESCRIPTION
## Summary

- New `scripts/manual-maven-central-sync.sh` — pushes an existing JFrog build to Maven Central after the fact (mirrors the CI `maven-central.yaml` flow: JFrog download + checksum loop + Central Portal API upload). For the case where `mavenCentralSync` was skipped at release time and we don't want to re-run the full release.
- CI now passes a meaningful `DEPLOYMENT_NAME` (e.g. `sonar-dotnet-enterprise-140279`) via the `/api/v1/publisher/upload?name=...` query parameter, instead of the generic `central-bundle.zip` previously shown on Central Portal. Backward-compatible: `maven-central-publish.sh` falls back to `central-bundle` when the env var is unset, so any caller that doesn't forward `DEPLOYMENT_NAME` behaves as before.
- README pointer + Confluence wiki page ([Manual Sync — Maven Central](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/2401697818)) rewrite to match the current Central Portal flow (the wiki was still documenting the legacy OSSRH/Nexus + Docker procedure).

## Context

Triggered by [PREQ-6069](https://sonarsource.atlassian.net/browse/PREQ-6069) — two sonar-dotnet-enterprise releases (10.26.0.140279, 10.27.0.140913) had to be manually pushed to Maven Central because `mavenCentralSync: false` was passed by mistake at release time. Both were validated end-to-end with the new script before this PR.

## Notes for reviewers

- `inputs.projectName != '' && inputs.projectName || github.event.repository.name` mirrors the same fallback `download-build/action.yml` already uses for `project-name`. Today only `sonar-enterprise` needs the override (→ `sonar-enterprise-sqcb`).
- The CI rename only takes effect for repos referencing this workflow via `@master` or via a tag re-cut after merge. The `sonar-dotnet-enterprise` `release.yml` still pins `@v6`; if we want immediate effect for that repo, either re-tag `v6` on master after merge or bump their pin.
- `maven-central-sync/action.yml` intentionally does **not** expose `deployment-name` as an input — `DEPLOYMENT_NAME` is set via `env:` on the calling step in `maven-central.yaml`, the same pattern `main.yaml` already uses for `INPUT_VERSION` / `ARTIFACTORY_ACCESS_TOKEN`. Internal contract, not a public API.

## Test plan

- [x] Local script run end-to-end against `sonar-dotnet-enterprise/140279` → `PUBLISHED` on Central Portal as `sonar-dotnet-enterprise-140279`.
- [x] Local script run end-to-end against `sonar-dotnet-enterprise/140913` → `PUBLISHED` on Central Portal as `sonar-dotnet-enterprise-140913`.
- [x] `shellcheck` passes (via pre-commit).
- [x] `yamllint`/`actionlint` pass (via pre-commit).
- [ ] CI dogfooding once merged: confirm the next real Maven Central sync deployment is labeled `<project>-<build>` on Central Portal instead of `central-bundle.zip`.

[PREQ-6069]: https://sonarsource.atlassian.net/browse/PREQ-6069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ