### PR TITLE
BUILD-10781 Bump JS deps in reusable + internal workflows to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Vault Secrets
         id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: ${{ env.VAULT_ADDR }}
           method: jwt

--- a/.github/workflows/it-test-download-build.yml
+++ b/.github/workflows/it-test-download-build.yml
@@ -27,7 +27,7 @@ jobs:
           # use default values for the following:
           #flat-download:
           #exclusions:
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then outputs.jfrog_dl_options value must contains --flat, --exclusions and --dry-run
         with:
           expected: '--exclusions - --dry-run=true'
@@ -55,7 +55,7 @@ jobs:
           flat-download: 'true'
           exclusions: '-'
           local-repo-dir: '.'
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then outputs.jfrog_dl_options value must contains --flat, --exclusions and --dry-run
         with:
           expected: '--exclusions - --dry-run=true --flat'

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -68,7 +68,7 @@ jobs:
         run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: ${{ inputs.vaultAddr }}
           secrets:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -196,7 +196,7 @@ jobs:
       - name: Vault Secrets
         id: secrets
         if: ${{ inputs.dryRun != true }}
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: ${{ inputs.vaultAddr }}
           secrets: |
@@ -207,7 +207,7 @@ jobs:
       - name: Vault Binaries AWS Secrets
         id: secrets-binaries-aws
         if: ${{ inputs.dryRun != true && inputs.publishToBinaries }}
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: ${{ inputs.vaultAddr }}
           secrets: |
@@ -427,7 +427,7 @@ jobs:
 
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: ${{ inputs.vaultAddr }}
           secrets:

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -58,7 +58,7 @@ jobs:
         run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: ${{ inputs.vaultAddr }}
           secrets:

--- a/.github/workflows/npmjs.yaml
+++ b/.github/workflows/npmjs.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Retrieve Secrets from Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: ${{ inputs.vaultAddr }}
           secrets: |

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -65,7 +65,7 @@ jobs:
         run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: ${{ inputs.vaultAddr }}
           secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: get secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-release token | github_token;

--- a/.github/workflows/test-javadoc-logic.yml
+++ b/.github/workflows/test-javadoc-logic.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install tools with mise
-        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.2.3
           install: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -15,7 +15,7 @@
           contents: write
         steps:
           - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-          - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+          - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
             with:
               version: 2026.2.3
           - name: Run IRIS Analysis

--- a/.github/workflows/update-v-branch.yml
+++ b/.github/workflows/update-v-branch.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: get secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
               development/github/token/{REPO_OWNER_NAME_DASH}-release token | github_token;


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 on Actions runners starting **2026-06-02**. The 5 reusable workflows in this repo (`main.yaml`, `maven-central.yaml`, `javadoc-publication.yaml`, `npmjs.yaml`, `pypi.yaml`) are consumed via `workflow_call` by every SonarSource product release pipeline — stale Node 20 pins here propagate to every product release.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

| Pin | Old | New | Why |
|---|---|---|---|
| `hashicorp/vault-action` | v3.4.0 | **v4.0.0** | Node 24 |
| `SonarSource/vault-action-wrapper` | 3.4.0 | **3.5.0** | Node 24 internals (`github-script@v9` + `vault-action@v4`) |
| `nick-fields/assert-action` | v2.0.0 | **v3.0.0** | Explicit Node 24 |
| `jdx/mise-action` | v3.6.3 | **v4.0.1** | Current major |

11 files touched, 14 insertions / 14 deletions.

## Not in scope here

- **`8398a7/action-slack@v3.19.0`** is both Node 20 AND upstream-deprecated (the action's `action.yml` carries a `deprecated:` flag pointing to `slackapi/slack-github-action`). It's used in 3 workflows (`maven-central.yaml`, `npmjs.yaml`, `pypi.yaml`) and needs a migration, not a bump. Tracked under [BUILD-11518](https://sonarsource.atlassian.net/browse/BUILD-11518).
- The other open Renovate PRs (#399, #389) overlap with parts of this; they can be closed after this lands.

## Verification

- `pre-commit` clean (yamllint, actionlint, validate workflows).
- CI on this PR exercises the IT workflows and Slack flows (the latter still on the deprecated action — that's expected until BUILD-11518).


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11518]: https://sonarsource.atlassian.net/browse/BUILD-11518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ