### PR TITLE
BUILD-10781 Bump jfrog-setup-wrapper pin to 3.7.0

### DIFF
--- a/.github/workflows/it-test-download-build.yml
+++ b/.github/workflows/it-test-download-build.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # 3.6.0
+        uses: SonarSource/jfrog-setup-wrapper@b243f5b25440cdcb062db329eec5fd9c9cd2dab2 # 3.7.0
         with:
           artifactoryRoleSuffix: "private-reader"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (Necessary to access local action)
@@ -42,7 +42,7 @@ jobs:
       contents: write
     steps:
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # 3.6.0
+        uses: SonarSource/jfrog-setup-wrapper@b243f5b25440cdcb062db329eec5fd9c9cd2dab2 # 3.7.0
         with:
           artifactoryRoleSuffix: "private-reader"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (Necessary to access local action)

--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -78,7 +78,7 @@ jobs:
             development/aws/sts/javadocs secret_key | javadoc_aws_secret_access_key;
             development/aws/sts/javadocs security_token | javadoc_aws_security_token;
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # 3.6.0
+        uses: SonarSource/jfrog-setup-wrapper@b243f5b25440cdcb062db329eec5fd9c9cd2dab2 # 3.7.0
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Create a path filter from the groupId for artifactory build search

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -66,7 +66,7 @@ jobs:
             development/kv/data/ossrh token | central_token;
             development/kv/data/slack webhook | slack_webhook;
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # 3.6.0
+        uses: SonarSource/jfrog-setup-wrapper@b243f5b25440cdcb062db329eec5fd9c9cd2dab2 # 3.7.0
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts

--- a/.github/workflows/npmjs.yaml
+++ b/.github/workflows/npmjs.yaml
@@ -83,7 +83,7 @@ jobs:
             development/kv/data/slack webhook | slack_webhook;
 
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # 3.6.0
+        uses: SonarSource/jfrog-setup-wrapper@b243f5b25440cdcb062db329eec5fd9c9cd2dab2 # 3.7.0
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -73,7 +73,7 @@ jobs:
             development/kv/data/${{ inputs.vaultTokenKey }} token | pypi_token;
             development/kv/data/slack webhook | slack_webhook;
       - name: Setup JFrog
-        uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # 3.6.0
+        uses: SonarSource/jfrog-setup-wrapper@b243f5b25440cdcb062db329eec5fd9c9cd2dab2 # 3.7.0
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Download Artifacts


### PR DESCRIPTION
## Why

`SonarSource/jfrog-setup-wrapper@3.7.0` ([release](https://github.com/SonarSource/jfrog-setup-wrapper/releases/tag/3.7.0)) ships `jfrog/setup-jfrog-cli@v5.0.0` (Node 24). Pinned consumers on `3.6.0` here still pull in the Node 20 setup-jfrog-cli — surfacing as the deprecation warning on `release / Javadoc publication / Publish javadoc`:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: `jfrog/setup-jfrog-cli@f748a0599171a192a2668afee8d0497f7c1069df`

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

6 references across 5 files bumped from `jfrog-setup-wrapper@e0f353c7 # 3.6.0` → `@b243f5b2 # 3.7.0`:

- `pypi.yaml`
- `npmjs.yaml`
- `maven-central.yaml`
- `javadoc-publication.yaml`
- `it-test-download-build.yml` (2 occurrences)

## Verification

`pre-commit` clean (yamllint, actionlint, Validate GitHub Workflows).

## Other org-wide consumers of the old 3.6.0 SHA

Found via code search — flagging so the appropriate owners can bump:

- `SonarSource/SonarJS` — `.github/workflows/release_eslint_plugin.yml`
- `SonarSource/ci-ami-images` — `.github/workflows/publish-digicert-smtools-to-repox.yml`
- `SonarSource/sonarqube-unification` — `.github/workflows/release-reusable.yml`


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ