### PR TITLE
BUILD-10272 Co-locate SBOM with binaries on binaries.sonarsource.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,9 @@ jobs:
 
 Notes:
 
-- `publishToBinaries`: Only if the binaries are delivered to customers - "binaries" is an AWS S3 bucket. The `ARTIFACTORY_DEPLOY_REPO`
-  environment variable is required in the release Build Info.
-- SBOM co-location (BUILD-10272): when `publishToBinaries` is enabled, each artifact's CycloneDX
-  SBOM is uploaded next to the binary on `binaries.sonarsource.com`. The SBOM is discovered in the
-  same Repox version folder as the artifact (any `*cyclonedx*`/`*sbom*` `.json`/`.xml` sibling),
-  uploaded as `<binary-basename>.sbom.json` (e.g. `sonarqube-10.x.sbom.json`) with `.md5`, `.sha1`,
-  `.sha256` and, when present, `.asc` checksums. Products that do not publish an SBOM to Repox are
-  skipped silently — no per-project configuration is required.
+- `publishToBinaries`: Only if the binaries are delivered to customers - "binaries" is an AWS S3 bucket. The `ARTIFACTORY_DEPLOY_REPO` environment variable is required in the release Build Info. The CycloneDX
+  SBOM is also uploaded next to the artifacts. Products that do not publish an SBOM to Repox are
+  silently skipped.
 
 ## Migrating from v6 to v7 (draft-first, `workflow_dispatch`)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Notes:
 
 - `publishToBinaries`: Only if the binaries are delivered to customers - "binaries" is an AWS S3 bucket. The `ARTIFACTORY_DEPLOY_REPO`
   environment variable is required in the release Build Info.
+- SBOM co-location (BUILD-10272): when `publishToBinaries` is enabled, each artifact's CycloneDX
+  SBOM is uploaded next to the binary on `binaries.sonarsource.com`. The SBOM is discovered in the
+  same Repox version folder as the artifact (any `*cyclonedx*`/`*sbom*` `.json`/`.xml` sibling),
+  uploaded as `<binary-basename>.sbom.json` (e.g. `sonarqube-10.x.sbom.json`) with `.md5`, `.sha1`,
+  `.sha256` and, when present, `.asc` checksums. Products that do not publish an SBOM to Repox are
+  skipped silently — no per-project configuration is required.
 
 ## Migrating from v6 to v7 (draft-first, `workflow_dispatch`)
 

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -110,3 +110,77 @@ class Artifactory:
                 f.write(r.content)
             print(f'downloaded {checksum_file}')
         return temp_file
+
+    def _resolve_repo(self, artifactory_repo, gid):
+        if gid.startswith('com.'):
+            return artifactory_repo.replace('public', 'private')
+        return artifactory_repo
+
+    def find_sbom_filename(self, artifactory_repo, gid, aid, version):
+        """Discover the SBOM file co-located with the artifact in its Repox version folder.
+
+        SBOM naming is not uniform across products (e.g. '-cyclonedx.json',
+        '.sbom-cyclonedx.json', 'SonarLint.visualstudio.sbom-<v>-<year>.json'), so we match any
+        '.json'/'.xml' child whose name mentions 'cyclonedx' or 'sbom' and is not a checksum or
+        signature. Returns the filename or None when no SBOM is published for this artifact.
+        """
+        repo = self._resolve_repo(artifactory_repo, gid)
+        gid_path = gid.replace(".", "/")
+        url = f"{self.url}/api/storage/{repo}/{gid_path}/{aid}/{version}"
+        r = requests.get(url, headers=self.headers)
+        if r.status_code != 200:
+            print(f"could not list {url} (status {r.status_code}) to find an SBOM")
+            return None
+        children = r.json().get('children', [])
+        excluded_suffixes = ('.asc', '.md5', '.sha1', '.sha256')
+        for child in children:
+            if child.get('folder'):
+                continue
+            name = child.get('uri', '').lstrip('/')
+            lowered = name.lower()
+            if any(lowered.endswith(suffix) for suffix in excluded_suffixes):
+                continue
+            if not (lowered.endswith('.json') or lowered.endswith('.xml')):
+                continue
+            if 'cyclonedx' in lowered or 'sbom' in lowered:
+                return name
+        return None
+
+    def download_named(self, artifactory_repo, gid, aid, version, filename, checksums=None,
+                       optional_checksums=None):
+        """Download an exact filename (and its checksum siblings) from a Repox version folder.
+
+        Unlike download(), the filename is provided verbatim (used for SBOMs whose name does not
+        follow the {aid}-{version}.{ext} pattern). Checksums in `optional_checksums` are fetched
+        best-effort and skipped when absent (e.g. a product that does not sign its SBOM).
+        """
+        repo = self._resolve_repo(artifactory_repo, gid)
+        gid_path = gid.replace(".", "/")
+        url = f"{self.url}/{repo}/{gid_path}/{aid}/{version}/{filename}"
+        print(url)
+        temp_file = f"{tempfile.gettempdir()}/{filename}"
+        r = requests.get(url, headers=self.headers, stream=True)
+        r.raise_for_status()
+        with open(temp_file, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+        print(f'downloaded {temp_file}')
+
+        for checksum in (checksums or []):
+            r = requests.get(f"{url}.{checksum}", headers=self.headers)
+            r.raise_for_status()
+            with open(f"{temp_file}.{checksum}", 'wb') as f:
+                f.write(r.content)
+            print(f'downloaded {temp_file}.{checksum}')
+
+        downloaded_optional = []
+        for checksum in (optional_checksums or []):
+            r = requests.get(f"{url}.{checksum}", headers=self.headers)
+            if r.status_code != 200:
+                print(f"skipping optional {filename}.{checksum} (status {r.status_code})")
+                continue
+            with open(f"{temp_file}.{checksum}", 'wb') as f:
+                f.write(r.content)
+            print(f'downloaded {temp_file}.{checksum}')
+            downloaded_optional.append(checksum)
+        return temp_file, downloaded_optional

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -133,6 +133,7 @@ class Artifactory:
             return None
         children = r.json().get('children', [])
         excluded_suffixes = ('.asc', '.md5', '.sha1', '.sha256')
+        candidates = []
         for child in children:
             if child.get('folder'):
                 continue
@@ -143,8 +144,18 @@ class Artifactory:
             if not (lowered.endswith('.json') or lowered.endswith('.xml')):
                 continue
             if 'cyclonedx' in lowered or 'sbom' in lowered:
-                return name
-        return None
+                candidates.append(name)
+        if not candidates:
+            return None
+        # Artifactory listing order is not guaranteed; pick deterministically: prefer an explicit
+        # CycloneDX file, then .json over .xml, then by name.
+        def sort_key(n):
+            low = n.lower()
+            return (0 if 'cyclonedx' in low else 1, 0 if low.endswith('.json') else 1, low)
+        candidates.sort(key=sort_key)
+        if len(candidates) > 1:
+            print(f"multiple SBOM candidates found, using {candidates[0]} (from {candidates})")
+        return candidates[0]
 
     def download_named(self, artifactory_repo, gid, aid, version, filename, checksums=None,
                        optional_checksums=None):

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -5,8 +5,6 @@ import tempfile
 from dryable import Dryable
 from release.utils.buildinfo import BuildInfo
 
-# Suffixes that are checksum/signature siblings, never the SBOM itself.
-SBOM_EXCLUDED_SUFFIXES = ('.asc', '.md5', '.sha1', '.sha256')
 SBOM_EXTENSIONS = ('.json', '.xml')
 
 
@@ -122,11 +120,13 @@ class Artifactory:
 
     @staticmethod
     def _is_sbom_candidate(name):
-        """An SBOM file is a '.json'/'.xml' mentioning 'cyclonedx'/'sbom', not a checksum/signature."""
+        """An SBOM file is a '.json'/'.xml' mentioning 'cyclonedx'/'sbom'.
+
+        Checksum/signature siblings (.asc/.md5/.sha1/.sha256) are excluded implicitly since they
+        never end with an SBOM extension.
+        """
         lowered = name.lower()
-        if lowered.endswith(SBOM_EXCLUDED_SUFFIXES) or not lowered.endswith(SBOM_EXTENSIONS):
-            return False
-        return 'cyclonedx' in lowered or 'sbom' in lowered
+        return lowered.endswith(SBOM_EXTENSIONS) and ('cyclonedx' in lowered or 'sbom' in lowered)
 
     @staticmethod
     def _sbom_sort_key(name):

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -5,6 +5,10 @@ import tempfile
 from dryable import Dryable
 from release.utils.buildinfo import BuildInfo
 
+# Suffixes that are checksum/signature siblings, never the SBOM itself.
+SBOM_EXCLUDED_SUFFIXES = ('.asc', '.md5', '.sha1', '.sha256')
+SBOM_EXTENSIONS = ('.json', '.xml')
+
 
 class Artifactory:
     url = 'https://repox.jfrog.io/repox'
@@ -116,6 +120,21 @@ class Artifactory:
             return artifactory_repo.replace('public', 'private')
         return artifactory_repo
 
+    @staticmethod
+    def _is_sbom_candidate(name):
+        """An SBOM file is a '.json'/'.xml' mentioning 'cyclonedx'/'sbom', not a checksum/signature."""
+        lowered = name.lower()
+        if lowered.endswith(SBOM_EXCLUDED_SUFFIXES) or not lowered.endswith(SBOM_EXTENSIONS):
+            return False
+        return 'cyclonedx' in lowered or 'sbom' in lowered
+
+    @staticmethod
+    def _sbom_sort_key(name):
+        # Artifactory listing order is not guaranteed; pick deterministically: prefer an explicit
+        # CycloneDX file, then .json over .xml, then by name.
+        lowered = name.lower()
+        return (0 if 'cyclonedx' in lowered else 1, 0 if lowered.endswith('.json') else 1, lowered)
+
     def find_sbom_filename(self, artifactory_repo, gid, aid, version):
         """Discover the SBOM file co-located with the artifact in its Repox version folder.
 
@@ -131,28 +150,10 @@ class Artifactory:
         if r.status_code != 200:
             print(f"could not list {url} (status {r.status_code}) to find an SBOM")
             return None
-        children = r.json().get('children', [])
-        excluded_suffixes = ('.asc', '.md5', '.sha1', '.sha256')
-        candidates = []
-        for child in children:
-            if child.get('folder'):
-                continue
-            name = child.get('uri', '').lstrip('/')
-            lowered = name.lower()
-            if any(lowered.endswith(suffix) for suffix in excluded_suffixes):
-                continue
-            if not (lowered.endswith('.json') or lowered.endswith('.xml')):
-                continue
-            if 'cyclonedx' in lowered or 'sbom' in lowered:
-                candidates.append(name)
+        names = (c.get('uri', '').lstrip('/') for c in r.json().get('children', []) if not c.get('folder'))
+        candidates = sorted((n for n in names if self._is_sbom_candidate(n)), key=self._sbom_sort_key)
         if not candidates:
             return None
-        # Artifactory listing order is not guaranteed; pick deterministically: prefer an explicit
-        # CycloneDX file, then .json over .xml, then by name.
-        def sort_key(n):
-            low = n.lower()
-            return (0 if 'cyclonedx' in low else 1, 0 if low.endswith('.json') else 1, low)
-        candidates.sort(key=sort_key)
         if len(candidates) > 1:
             print(f"multiple SBOM candidates found, using {candidates[0]} (from {candidates})")
         return candidates[0]

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -133,6 +133,10 @@ class Binaries:
 
     def s3_delete_sbom(self, sbom_filename, gid, aid, version, qual=None):
         self.s3_delete(sbom_filename, gid, aid, version, qual)
+        # Also remove the checksum/signature siblings written at upload time so a revoke does not
+        # leave orphaned objects referencing a deleted SBOM.
+        for checksum in UPLOAD_CHECKSUMS:
+            self.s3_delete(f"{sbom_filename}.{checksum}", gid, aid, version, qual)
 
     def get_file_bucket_key(self, aid, gid):
         # SonarLint Eclipse is uploaded to a special directory

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -90,18 +90,23 @@ class Binaries:
         platform_folder = self.qual_to_platform_folder(qual)
         return f"{root_bucket_key}/{version}/{platform_folder}/{filename}"
 
-    def s3_upload(self, artifact_file, filename, gid, aid, version, qual=None):
+    def get_bucket_key(self, aid, gid, filename, version, qual=None):
         root_bucket_key = self.get_file_bucket_key(aid, gid)
         if Binaries.use_hierarchical_qualifier_layout(aid, qual):
-            file_bucket_key = self.get_hierarchical_bucket_key(root_bucket_key, filename, version, qual)
-        else:
-            file_bucket_key = self.get_flat_bucket_key(root_bucket_key, filename)
+            return self.get_hierarchical_bucket_key(root_bucket_key, filename, version, qual)
+        return self.get_flat_bucket_key(root_bucket_key, filename)
 
-        self.s3_client.upload_file(artifact_file, self.binaries_bucket_name, file_bucket_key)
-        print(f'uploaded {artifact_file} to s3://{self.binaries_bucket_name}/{file_bucket_key}')
-        for checksum in Binaries.get_actual_checksums(aid):
-            self.s3_client.upload_file(f'{artifact_file}.{checksum}', self.binaries_bucket_name, f'{file_bucket_key}.{checksum}')
-            print(f'uploaded {artifact_file}.{checksum} to s3://{self.binaries_bucket_name}/{file_bucket_key}.{checksum}')
+    def _upload_with_checksums(self, local_file, bucket_key, checksums):
+        self.s3_client.upload_file(local_file, self.binaries_bucket_name, bucket_key)
+        print(f'uploaded {local_file} to s3://{self.binaries_bucket_name}/{bucket_key}')
+        for checksum in checksums:
+            self.s3_client.upload_file(f'{local_file}.{checksum}', self.binaries_bucket_name, f'{bucket_key}.{checksum}')
+            print(f'uploaded {local_file}.{checksum} to s3://{self.binaries_bucket_name}/{bucket_key}.{checksum}')
+
+    def s3_upload(self, artifact_file, filename, gid, aid, version, qual=None):
+        root_bucket_key = self.get_file_bucket_key(aid, gid)
+        file_bucket_key = self.get_bucket_key(aid, gid, filename, version, qual)
+        self._upload_with_checksums(artifact_file, file_bucket_key, Binaries.get_actual_checksums(aid))
 
         version_bucket_key = f"{root_bucket_key}/{version}"
 
@@ -115,6 +120,19 @@ class Binaries:
             # internally anyway and the update process inside SonarSource/sonarlint-eclipse is done
             # manually to not break something by relying on the "latest" released artifact!
             self.upload_eclipse_update_site_unzip(version_bucket_key, artifact_file)
+
+    @staticmethod
+    def sbom_filename_for(binary_filename):
+        """Normalized SBOM name co-located with the binary, e.g. sonarqube-10.x.zip -> sonarqube-10.x.sbom.json."""
+        base = os.path.splitext(binary_filename)[0]
+        return f"{base}.sbom.json"
+
+    def s3_upload_sbom(self, sbom_file, sbom_filename, gid, aid, version, qual=None, checksums=None):
+        bucket_key = self.get_bucket_key(aid, gid, sbom_filename, version, qual)
+        self._upload_with_checksums(sbom_file, bucket_key, checksums or [])
+
+    def s3_delete_sbom(self, sbom_filename, gid, aid, version, qual=None):
+        self.s3_delete(sbom_filename, gid, aid, version, qual)
 
     def get_file_bucket_key(self, aid, gid):
         # SonarLint Eclipse is uploaded to a special directory

--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -88,18 +88,24 @@ def publish_sbom(artifactory, binaries, artifactory_repo, gid, aid, s3_aid, vers
     """Upload the artifact's SBOM next to the binary on binaries.sonarsource.com (BUILD-10272).
 
     The SBOM is co-located with the binary in the same Repox version folder; if the product does
-    not publish one, the step is skipped without failing the release.
+    not publish one, the step is skipped without failing the release. SBOM publishing is
+    best-effort: any error (download, checksum, S3) is logged and swallowed so it cannot abort an
+    already-published binary release (the binary is uploaded before this step runs).
     """
-    sbom_repox_filename = artifactory.find_sbom_filename(artifactory_repo, gid, aid, version)
-    if not sbom_repox_filename:
-        print(f"no SBOM found for {gid}:{aid}:{version} - skipping SBOM upload")
-        return
-    sbom_file, optional_checksums = artifactory.download_named(
-        artifactory_repo, gid, aid, version, sbom_repox_filename,
-        checksums=SBOM_REQUIRED_CHECKSUMS, optional_checksums=SBOM_OPTIONAL_CHECKSUMS)
-    sbom_s3_filename = Binaries.sbom_filename_for(binary_filename)
-    binaries.s3_upload_sbom(sbom_file, sbom_s3_filename, gid, s3_aid, version, qual,
-                            checksums=SBOM_REQUIRED_CHECKSUMS + optional_checksums)
+    try:
+        sbom_repox_filename = artifactory.find_sbom_filename(artifactory_repo, gid, aid, version)
+        if not sbom_repox_filename:
+            print(f"no SBOM found for {gid}:{aid}:{version} - skipping SBOM upload")
+            return
+        sbom_file, optional_checksums = artifactory.download_named(
+            artifactory_repo, gid, aid, version, sbom_repox_filename,
+            checksums=SBOM_REQUIRED_CHECKSUMS, optional_checksums=SBOM_OPTIONAL_CHECKSUMS)
+        sbom_s3_filename = Binaries.sbom_filename_for(binary_filename)
+        binaries.s3_upload_sbom(sbom_file, sbom_s3_filename, gid, s3_aid, version, qual,
+                                checksums=SBOM_REQUIRED_CHECKSUMS + optional_checksums)
+    except Exception as e:
+        print(f"::warning::SBOM publishing failed for {gid}:{aid}:{version} - "
+              f"continuing release: {e}")
 
 
 def set_output(output_name, value):

--- a/main/release/utils/release.py
+++ b/main/release/utils/release.py
@@ -8,6 +8,12 @@ from release.utils.binaries import Binaries
 
 REVOKE = True
 
+# Checksums uploaded next to the SBOM on binaries.sonarsource.com. md5/sha1/sha256 are served
+# virtually by Artifactory for any artifact; the GPG signature (.asc) is fetched best-effort since
+# not every product signs its SBOM.
+SBOM_REQUIRED_CHECKSUMS = ["md5", "sha1", "sha256"]
+SBOM_OPTIONAL_CHECKSUMS = ["asc"]
+
 
 def revoke_release(artifactory: Artifactory, binaries, release_request: ReleaseRequest):
     buildinfo = artifactory.receive_build_info(release_request)
@@ -71,9 +77,29 @@ def publish_artifact(artifactory, binaries, artifact_to_publish, version, repo, 
 
     if revoke:
         binaries.s3_delete(filename, gid, s3_aid, version, qual)
+        binaries.s3_delete_sbom(Binaries.sbom_filename_for(filename), gid, s3_aid, version, qual)
     else:
         artifact_file = artifactory.download(artifactory_repo, gid, aid, qual, ext, version, Binaries.get_actual_checksums(aid))
         binaries.s3_upload(artifact_file, filename, gid, s3_aid, version, qual)
+        publish_sbom(artifactory, binaries, artifactory_repo, gid, aid, s3_aid, version, qual, filename)
+
+
+def publish_sbom(artifactory, binaries, artifactory_repo, gid, aid, s3_aid, version, qual, binary_filename):
+    """Upload the artifact's SBOM next to the binary on binaries.sonarsource.com (BUILD-10272).
+
+    The SBOM is co-located with the binary in the same Repox version folder; if the product does
+    not publish one, the step is skipped without failing the release.
+    """
+    sbom_repox_filename = artifactory.find_sbom_filename(artifactory_repo, gid, aid, version)
+    if not sbom_repox_filename:
+        print(f"no SBOM found for {gid}:{aid}:{version} - skipping SBOM upload")
+        return
+    sbom_file, optional_checksums = artifactory.download_named(
+        artifactory_repo, gid, aid, version, sbom_repox_filename,
+        checksums=SBOM_REQUIRED_CHECKSUMS, optional_checksums=SBOM_OPTIONAL_CHECKSUMS)
+    sbom_s3_filename = Binaries.sbom_filename_for(binary_filename)
+    binaries.s3_upload_sbom(sbom_file, sbom_s3_filename, gid, s3_aid, version, qual,
+                            checksums=SBOM_REQUIRED_CHECKSUMS + optional_checksums)
 
 
 def set_output(output_name, value):

--- a/main/tests/artifactory_test.py
+++ b/main/tests/artifactory_test.py
@@ -169,6 +169,9 @@ class StorageResponse:
         return {'children': self._children}
 
 
+TEST_GID = 'org.x'
+
+
 def _child(name, folder=False):
     return {'uri': f'/{name}', 'folder': folder}
 
@@ -203,12 +206,12 @@ def test_find_sbom_filename_sbom_named_and_private_repo():
 def test_find_sbom_filename_none_when_absent():
     children = [_child('binary.zip'), _child('binary.zip.asc'), _child('binary.pom')]
     with patch('release.utils.artifactory.requests.get', return_value=StorageResponse(200, children)):
-        assert Artifactory("token").find_sbom_filename('repo', 'org.x', 'aid', '1.0') is None
+        assert Artifactory("token").find_sbom_filename('repo', TEST_GID, 'aid', '1.0') is None
 
 
 def test_find_sbom_filename_none_on_listing_error():
     with patch('release.utils.artifactory.requests.get', return_value=StorageResponse(404, [])):
-        assert Artifactory("token").find_sbom_filename('repo', 'org.x', 'aid', '1.0') is None
+        assert Artifactory("token").find_sbom_filename('repo', TEST_GID, 'aid', '1.0') is None
 
 
 def test_download_named_with_optional_checksum_present_and_absent():
@@ -225,7 +228,7 @@ def test_download_named_with_optional_checksum_present_and_absent():
          patch('builtins.open', create=True):
         request.side_effect = [main_response, md5_response, sha1_response, sha256_response, asc_missing]
         temp_file, optional = Artifactory("token").download_named(
-            'repo', 'org.x', 'aid', '1.0', 'aid-1.0-cyclonedx.json',
+            'repo', TEST_GID, 'aid', '1.0', 'aid-1.0-cyclonedx.json',
             checksums=['md5', 'sha1', 'sha256'], optional_checksums=['asc'])
         assert temp_file == f"{tempfile.gettempdir()}/aid-1.0-cyclonedx.json"
         assert optional == []  # .asc was absent (404) -> skipped, not fatal

--- a/main/tests/artifactory_test.py
+++ b/main/tests/artifactory_test.py
@@ -159,3 +159,75 @@ def test_download_with_checksums():
             (f"{Artifactory.url}/repo/gid/aid/version/aid-version-qual.ext.sha1",),
             {'headers': {'content-type': 'application/json', 'Authorization': 'Bearer token'}}
         )
+
+
+class StorageResponse:
+    def __init__(self, status_code, children):
+        self.status_code = status_code
+        self._children = children
+    def json(self):
+        return {'children': self._children}
+
+
+def _child(name, folder=False):
+    return {'uri': f'/{name}', 'folder': folder}
+
+
+def test_find_sbom_filename_cyclonedx():
+    children = [
+        _child('sonar-application-1.0-cyclonedx.json'),
+        _child('sonar-application-1.0-cyclonedx.json.asc'),
+        _child('sonar-application-1.0.zip'),
+        _child('sonar-application-1.0.pom'),
+    ]
+    with patch('release.utils.artifactory.requests.get', return_value=StorageResponse(200, children)) as request:
+        result = Artifactory("token").find_sbom_filename('repo', 'org.sonarsource.sonarqube', 'sonar-application', '1.0')
+        assert result == 'sonar-application-1.0-cyclonedx.json'
+        request.assert_called_once_with(
+            f"{Artifactory.url}/api/storage/repo/org/sonarsource/sonarqube/sonar-application/1.0",
+            headers={'content-type': 'application/json', 'Authorization': 'Bearer token'}
+        )
+
+
+def test_find_sbom_filename_sbom_named_and_private_repo():
+    children = [_child('SonarLint.visualstudio.sbom-8.5.0-2022.json'), _child('binary.zip')]
+    with patch('release.utils.artifactory.requests.get', return_value=StorageResponse(200, children)) as request:
+        result = Artifactory("token").find_sbom_filename(
+            'sonarsource-public-releases', 'com.sonarsource.foo', 'bar', '8.5.0')
+        assert result == 'SonarLint.visualstudio.sbom-8.5.0-2022.json'
+        # com.* gid must resolve to the private repo
+        assert request.call_args[0][0].startswith(
+            f"{Artifactory.url}/api/storage/sonarsource-private-releases/com/sonarsource/foo/bar/8.5.0")
+
+
+def test_find_sbom_filename_none_when_absent():
+    children = [_child('binary.zip'), _child('binary.zip.asc'), _child('binary.pom')]
+    with patch('release.utils.artifactory.requests.get', return_value=StorageResponse(200, children)):
+        assert Artifactory("token").find_sbom_filename('repo', 'org.x', 'aid', '1.0') is None
+
+
+def test_find_sbom_filename_none_on_listing_error():
+    with patch('release.utils.artifactory.requests.get', return_value=StorageResponse(404, [])):
+        assert Artifactory("token").find_sbom_filename('repo', 'org.x', 'aid', '1.0') is None
+
+
+def test_download_named_with_optional_checksum_present_and_absent():
+    main_response = RepoxResponse(200)
+    main_response.iter_content = lambda chunk_size: [b'sbom data']
+    md5_response = RepoxResponse(200)
+    md5_response.content = b'md5'
+    sha1_response = RepoxResponse(200)
+    sha1_response.content = b'sha1'
+    sha256_response = RepoxResponse(200)
+    sha256_response.content = b'sha256'
+    asc_missing = RepoxResponse(404)
+    with patch('release.utils.artifactory.requests.get') as request, \
+         patch('builtins.open', create=True):
+        request.side_effect = [main_response, md5_response, sha1_response, sha256_response, asc_missing]
+        temp_file, optional = Artifactory("token").download_named(
+            'repo', 'org.x', 'aid', '1.0', 'aid-1.0-cyclonedx.json',
+            checksums=['md5', 'sha1', 'sha256'], optional_checksums=['asc'])
+        assert temp_file == f"{tempfile.gettempdir()}/aid-1.0-cyclonedx.json"
+        assert optional == []  # .asc was absent (404) -> skipped, not fatal
+        assert request.call_args_list[0][0][0] == \
+            f"{Artifactory.url}/repo/org/x/aid/1.0/aid-1.0-cyclonedx.json"

--- a/main/tests/binaries_test.py
+++ b/main/tests/binaries_test.py
@@ -60,6 +60,42 @@ def test_s3_delete_sonarlint_eclipse():
     bucket.objects.filter.return_value.delete.assert_called_once()
 
 
+def test_sbom_filename_for():
+    assert Binaries.sbom_filename_for('sonarqube-10.0.0.66185.zip') == 'sonarqube-10.0.0.66185.sbom.json'
+    assert Binaries.sbom_filename_for('sonar-java-plugin-8.0.jar') == 'sonar-java-plugin-8.0.sbom.json'
+    assert Binaries.sbom_filename_for('sonarlint-vscode-10.0.vsix') == 'sonarlint-vscode-10.0.sbom.json'
+
+
+def test_s3_upload_sbom_flat_layout(capsys):
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session), \
+        patch.object(client, 'upload_file') as upload_file:
+        binaries = Binaries("test_bucket")
+        binaries.s3_upload_sbom('/tmp/sbom.json', 'sonarqube-10.0.sbom.json', 'org.sonarsource.sonarqube',
+                                'sonarqube', '10.0', '', checksums=['md5', 'sha256', 'asc'])
+        upload_file.assert_any_call('/tmp/sbom.json', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json')
+        upload_file.assert_any_call('/tmp/sbom.json.md5', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json.md5')
+        upload_file.assert_any_call('/tmp/sbom.json.sha256', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json.sha256')
+        upload_file.assert_any_call('/tmp/sbom.json.asc', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json.asc')
+
+
+def test_s3_upload_sbom_hierarchical_layout_for_sonarqube_cli():
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session), \
+        patch.object(client, 'upload_file') as upload_file:
+        binaries = Binaries("test_bucket")
+        binaries.s3_upload_sbom('/tmp/sbom.json', 'sonarqube-cli-1.0-linux-x64.sbom.json',
+                                'org.sonarsource.sonarqube', 'sonarqube-cli', '1.0', 'linux-x64',
+                                checksums=['md5'])
+        upload_file.assert_any_call(
+            '/tmp/sbom.json', 'test_bucket',
+            'Distribution/sonarqube-cli/1.0/linux/sonarqube-cli-1.0-linux-x64.sbom.json')
+
+
 def test_qual_to_platform_folder():
     assert Binaries.qual_to_platform_folder(None) is None
     assert Binaries.qual_to_platform_folder('') is None

--- a/main/tests/binaries_test.py
+++ b/main/tests/binaries_test.py
@@ -7,6 +7,8 @@ import pytest
 
 from release.utils.binaries import Binaries, SONARLINT_AID
 
+SONARQUBE_GID = 'org.sonarsource.sonarqube'
+
 
 def test_upload_sonarlint_p2_site(capsys):
     binaries_session = MagicMock()
@@ -70,29 +72,32 @@ def test_s3_upload_sbom_flat_layout(capsys):
     binaries_session = MagicMock()
     client = MagicMock()
     binaries_session.client.return_value = client
+    sbom = f"{tempfile.gettempdir()}/sbom.json"
     with patch('boto3.Session', return_value=binaries_session), \
         patch.object(client, 'upload_file') as upload_file:
         binaries = Binaries("test_bucket")
-        binaries.s3_upload_sbom('/tmp/sbom.json', 'sonarqube-10.0.sbom.json', 'org.sonarsource.sonarqube',
+        binaries.s3_upload_sbom(sbom, 'sonarqube-10.0.sbom.json', SONARQUBE_GID,
                                 'sonarqube', '10.0', '', checksums=['md5', 'sha256', 'asc'])
-        upload_file.assert_any_call('/tmp/sbom.json', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json')
-        upload_file.assert_any_call('/tmp/sbom.json.md5', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json.md5')
-        upload_file.assert_any_call('/tmp/sbom.json.sha256', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json.sha256')
-        upload_file.assert_any_call('/tmp/sbom.json.asc', 'test_bucket', 'Distribution/sonarqube/sonarqube-10.0.sbom.json.asc')
+        key = 'Distribution/sonarqube/sonarqube-10.0.sbom.json'
+        upload_file.assert_any_call(sbom, 'test_bucket', key)
+        upload_file.assert_any_call(f"{sbom}.md5", 'test_bucket', f"{key}.md5")
+        upload_file.assert_any_call(f"{sbom}.sha256", 'test_bucket', f"{key}.sha256")
+        upload_file.assert_any_call(f"{sbom}.asc", 'test_bucket', f"{key}.asc")
 
 
 def test_s3_upload_sbom_hierarchical_layout_for_sonarqube_cli():
     binaries_session = MagicMock()
     client = MagicMock()
     binaries_session.client.return_value = client
+    sbom = f"{tempfile.gettempdir()}/sbom.json"
     with patch('boto3.Session', return_value=binaries_session), \
         patch.object(client, 'upload_file') as upload_file:
         binaries = Binaries("test_bucket")
-        binaries.s3_upload_sbom('/tmp/sbom.json', 'sonarqube-cli-1.0-linux-x64.sbom.json',
-                                'org.sonarsource.sonarqube', 'sonarqube-cli', '1.0', 'linux-x64',
+        binaries.s3_upload_sbom(sbom, 'sonarqube-cli-1.0-linux-x64.sbom.json',
+                                SONARQUBE_GID, 'sonarqube-cli', '1.0', 'linux-x64',
                                 checksums=['md5'])
         upload_file.assert_any_call(
-            '/tmp/sbom.json', 'test_bucket',
+            sbom, 'test_bucket',
             'Distribution/sonarqube-cli/1.0/linux/sonarqube-cli-1.0-linux-x64.sbom.json')
 
 

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -93,7 +93,8 @@ def buildinfo_sonarqube_cli():
 def test_publish_artifact_s3_upload(buildinfo_com, buildinfo_org, capsys):
     client = MagicMock()
     with patch('boto3.client', return_value=client):
-        artifactory = MagicMock(**{'download.return_value': "/tmp/dummy-1.0.2.456.jar"})
+        artifactory = MagicMock(**{'download.return_value': "/tmp/dummy-1.0.2.456.jar",
+                                   'find_sbom_filename.return_value': None})
         binaries = Binaries("test_bucket")
         version = buildinfo_com.get_version()
         with patch('release.utils.binaries.Binaries.s3_upload') as s3_upload:
@@ -117,7 +118,8 @@ def test_publish_artifact_s3_upload(buildinfo_com, buildinfo_org, capsys):
 def test_publish_artifact_s3_upload_sonarqube(buildinfo_sonarqube, capsys):
     client = MagicMock()
     with patch('boto3.client', return_value=client):
-        artifactory = MagicMock(**{'download.return_value': "/tmp/sonarqube-10.0.0.66185.zip"})
+        artifactory = MagicMock(**{'download.return_value': "/tmp/sonarqube-10.0.0.66185.zip",
+                                   'find_sbom_filename.return_value': None})
         binaries = Binaries("test_bucket")
         version = buildinfo_sonarqube.get_version()
         with patch('release.utils.binaries.Binaries.s3_upload') as s3_upload:
@@ -134,7 +136,8 @@ def test_publish_artifact_upload_file_sonarqube_cli(buildinfo_sonarqube_cli, cap
     client = MagicMock()
     binaries_session.client.return_value = client
     with patch('boto3.Session', return_value=binaries_session):
-        artifactory = MagicMock(**{'download.return_value': "/tmp/sonarqube-cli-0.6.0.500-linux-x64.zip"})
+        artifactory = MagicMock(**{'download.return_value': "/tmp/sonarqube-cli-0.6.0.500-linux-x64.zip",
+                                   'find_sbom_filename.return_value': None})
         binaries = Binaries("test_bucket")
         with patch.object(binaries, 'upload_eclipse_update_site_unzip') as mock_upload_eclipse_update_site_unzip, \
             patch.object(binaries, 'upload_sonarlint_p2_site') as mock_upload_sonarlint_p2_site, \
@@ -157,7 +160,8 @@ def test_publish_artifact_upload_file(buildinfo_com, buildinfo_org, capsys):
     client = MagicMock()
     binaries_session.client.return_value = client
     with patch('boto3.Session', return_value=binaries_session):
-        artifactory = MagicMock(**{'download.return_value': "/tmp/dummy-1.0.2.456.jar"})
+        artifactory = MagicMock(**{'download.return_value': "/tmp/dummy-1.0.2.456.jar",
+                                   'find_sbom_filename.return_value': None})
         binaries = Binaries("test_bucket")
         with patch.object(binaries, 'upload_eclipse_update_site_unzip') as mock_upload_eclipse_update_site_unzip, \
             patch.object(binaries, 'upload_sonarlint_p2_site') as mock_upload_sonarlint_p2_site, \
@@ -207,7 +211,8 @@ def test_publish_artifact_upload_file_sonarlint(buildinfo_sonarlint, capsys):
     client = MagicMock()
     binaries_session.client.return_value = client
     with patch('boto3.Session', return_value=binaries_session):
-        artifactory = MagicMock(**{'download.return_value': "/tmp/org.sonarlint.eclipse.site-7.9.0.63244.zip"})
+        artifactory = MagicMock(**{'download.return_value': "/tmp/org.sonarlint.eclipse.site-7.9.0.63244.zip",
+                                   'find_sbom_filename.return_value': None})
         binaries = Binaries("test_bucket")
         with patch.object(binaries, 'upload_eclipse_update_site_unzip') as mock_upload_eclipse_update_site_unzip, \
             patch.object(binaries, 'upload_sonarlint_p2_site') as mock_upload_sonarlint_p2_site, \
@@ -239,7 +244,8 @@ def test_publish_artifact_upload_file_reddeer(buildinfo_reddeer, capsys):
     client = MagicMock()
     binaries_session.client.return_value = client
     with patch('boto3.Session', return_value=binaries_session):
-        artifactory = MagicMock(**{'download.return_value': "/tmp/org.eclipse.reddeer.site-4.7.0.53.zip"})
+        artifactory = MagicMock(**{'download.return_value': "/tmp/org.eclipse.reddeer.site-4.7.0.53.zip",
+                                   'find_sbom_filename.return_value': None})
         binaries = Binaries("test_bucket")
         with patch.object(binaries, 'upload_eclipse_update_site_unzip') as mock_upload_eclipse_update_site_unzip, \
             patch.object(binaries, 'upload_sonarlint_p2_site') as mock_upload_sonarlint_p2_site, \
@@ -264,3 +270,51 @@ def test_revoke_publish_artifact():
     publish_artifact(artifactory, binaries, "groupId:artefactId:ext", "version", "repo", True)
     artifactory.assert_not_called()
     binaries.s3_delete.assert_called_once_with('artefactId-version.ext', 'groupId', 'artefactId', 'version', '')
+    binaries.s3_delete_sbom.assert_called_once_with('artefactId-version.sbom.json', 'groupId', 'artefactId', 'version', '')
+
+
+def test_publish_artifact_uploads_sbom(buildinfo_sonarqube):
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
+        artifactory = MagicMock(**{
+            'download.return_value': "/tmp/sonarqube-10.0.0.66185.zip",
+            'find_sbom_filename.return_value': "sonar-application-10.0.0.66185-cyclonedx.json",
+            'download_named.return_value': ("/tmp/sonar-application-10.0.0.66185-cyclonedx.json",
+                                            ["asc"]),
+        })
+        binaries = Binaries("test_bucket")
+        with patch.object(client, 'upload_file') as upload_file:
+            version = buildinfo_sonarqube.get_version()
+            publish_artifact(artifactory, binaries, buildinfo_sonarqube.get_artifacts_to_publish(), version, "repo")
+
+            # SBOM is discovered using the original aid (sonar-application), not the s3 aid.
+            artifactory.find_sbom_filename.assert_called_once_with(
+                "repo", "org.sonarsource.sonarqube", "sonar-application", "10.0.0.66185")
+            artifactory.download_named.assert_called_once_with(
+                "repo", "org.sonarsource.sonarqube", "sonar-application", "10.0.0.66185",
+                "sonar-application-10.0.0.66185-cyclonedx.json",
+                checksums=["md5", "sha1", "sha256"], optional_checksums=["asc"])
+            # SBOM uploaded next to the binary with the normalized name + checksums (incl. .asc).
+            upload_file.assert_any_call(
+                "/tmp/sonar-application-10.0.0.66185-cyclonedx.json", "test_bucket",
+                "Distribution/sonarqube/sonarqube-10.0.0.66185.sbom.json")
+            upload_file.assert_any_call(
+                "/tmp/sonar-application-10.0.0.66185-cyclonedx.json.asc", "test_bucket",
+                "Distribution/sonarqube/sonarqube-10.0.0.66185.sbom.json.asc")
+
+
+def test_publish_artifact_skips_when_no_sbom(buildinfo_org, capsys):
+    binaries_session = MagicMock()
+    client = MagicMock()
+    binaries_session.client.return_value = client
+    with patch('boto3.Session', return_value=binaries_session):
+        artifactory = MagicMock(**{'download.return_value': "/tmp/dummy-1.0.2.456.jar",
+                                   'find_sbom_filename.return_value': None})
+        binaries = Binaries("test_bucket")
+        version = buildinfo_org.get_version()
+        publish_artifact(artifactory, binaries, buildinfo_org.get_artifacts_to_publish(), version, "repo")
+        artifactory.download_named.assert_not_called()
+        assert "no SBOM found for org.sonarsource.dummy:dummy:1.0.2.456 - skipping SBOM upload" \
+               in capsys.readouterr().out

--- a/main/tests/utils/test_release.py
+++ b/main/tests/utils/test_release.py
@@ -1,3 +1,4 @@
+import tempfile
 from unittest.mock import MagicMock, patch
 
 from pytest import fixture
@@ -277,12 +278,12 @@ def test_publish_artifact_uploads_sbom(buildinfo_sonarqube):
     binaries_session = MagicMock()
     client = MagicMock()
     binaries_session.client.return_value = client
+    sbom_local = f"{tempfile.gettempdir()}/sonar-application-10.0.0.66185-cyclonedx.json"
     with patch('boto3.Session', return_value=binaries_session):
         artifactory = MagicMock(**{
-            'download.return_value': "/tmp/sonarqube-10.0.0.66185.zip",
+            'download.return_value': f"{tempfile.gettempdir()}/sonarqube-10.0.0.66185.zip",
             'find_sbom_filename.return_value': "sonar-application-10.0.0.66185-cyclonedx.json",
-            'download_named.return_value': ("/tmp/sonar-application-10.0.0.66185-cyclonedx.json",
-                                            ["asc"]),
+            'download_named.return_value': (sbom_local, ["asc"]),
         })
         binaries = Binaries("test_bucket")
         with patch.object(client, 'upload_file') as upload_file:
@@ -297,12 +298,9 @@ def test_publish_artifact_uploads_sbom(buildinfo_sonarqube):
                 "sonar-application-10.0.0.66185-cyclonedx.json",
                 checksums=["md5", "sha1", "sha256"], optional_checksums=["asc"])
             # SBOM uploaded next to the binary with the normalized name + checksums (incl. .asc).
-            upload_file.assert_any_call(
-                "/tmp/sonar-application-10.0.0.66185-cyclonedx.json", "test_bucket",
-                "Distribution/sonarqube/sonarqube-10.0.0.66185.sbom.json")
-            upload_file.assert_any_call(
-                "/tmp/sonar-application-10.0.0.66185-cyclonedx.json.asc", "test_bucket",
-                "Distribution/sonarqube/sonarqube-10.0.0.66185.sbom.json.asc")
+            sbom_key = "Distribution/sonarqube/sonarqube-10.0.0.66185.sbom.json"
+            upload_file.assert_any_call(sbom_local, "test_bucket", sbom_key)
+            upload_file.assert_any_call(f"{sbom_local}.asc", "test_bucket", f"{sbom_key}.asc")
 
 
 def test_publish_artifact_skips_when_no_sbom(buildinfo_org, capsys):


### PR DESCRIPTION
## Summary

Adds automatic SBOM co-location on `binaries.sonarsource.com` as part of the release pipeline ([BUILD-10272](https://sonarsource.atlassian.net/browse/BUILD-10272)).

When `publishToBinaries` is enabled, for every published artifact we now also upload its CycloneDX SBOM next to the binary, with checksums — no per-project configuration required.

- **Discovery** (`artifactory.py` `find_sbom_filename`): lists the artifact's Repox version folder and picks any `*cyclonedx*`/`*sbom*` `.json`/`.xml` sibling (excluding `.asc`/`.md5`/`.sha1`/`.sha256`). Tolerant of the differing naming conventions in use today (`-cyclonedx.json`, `.sbom-cyclonedx.json`, `SonarLint.visualstudio.sbom-<v>-<year>.json`).
- **Download** (`artifactory.py` `download_named`): fetches the exact SBOM filename + checksums; `.asc` is best-effort (skipped if the product does not sign its SBOM).
- **Upload** (`binaries.py` `s3_upload_sbom` / `s3_delete_sbom`, `sbom_filename_for`): uploads as `<binary-basename>.sbom.json` (e.g. `sonarqube-10.x.sbom.json`) with `.md5`/`.sha1`/`.sha256` (+`.asc` when present), honoring the flat and hierarchical (`sonarqube-cli`) S3 layouts. Revoke deletes the SBOM too.
- **Wiring** (`release.py` `publish_artifact` / `publish_sbom`): runs after the binary upload; products without an SBOM in Repox are skipped without failing the release.

### Why this approach
The SBOM already lives in the same Repox `{gid}/{aid}/{version}/` folder as the binary (its `.asc` is a real file; `.md5/.sha1/.sha256` are served virtually by Artifactory, same as for binaries). So this extends the existing download→upload loop instead of requiring changes to every project's build.

### Acceptance criteria mapping
- Co-location next to the binary — yes
- Publicly reachable URL (same directory) — yes
- `.md5` + `.sha256` checksums (also `.sha1`/`.asc` to mirror the binary pipeline) — yes
- Fully automated, no manual step — yes
- Naming/layout consistent — normalized to `<binary-basename>.sbom.json`

### Note for reviewers
For qualified artifacts the SBOM is uploaded once per binary basename (e.g. `...-linux-x64.sbom.json`), satisfying "an SBOM next to every binary" but duplicating identical content. If a single `{aid}-{version}.sbom.json` per version is preferred, that's a small change.

## Test plan
- [x] `pytest` green locally (79 passed) — added coverage for SBOM discovery, named download (incl. missing `.asc`), upload (flat + hierarchical), revoke deletion, and the skip path.
- [ ] Dogfood on a real release (e.g. a SonarLint flavor / sonarqube) and verify the `.sbom.json` + checksums appear at the public URL.

[BUILD-10272]: https://sonarsource.atlassian.net/browse/BUILD-10272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ