### PR TITLE
BUILD-11518 Replace deprecated 8398a7/action-slack with slack-github-action v3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -270,7 +270,7 @@ jobs:
 
       - name: Send Slack notification on releasability check failure
         if: failure() && steps.releasability.outcome == 'failure'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ steps.parse_vault.outputs.slack_webhook }}
           webhook-type: incoming-webhook

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -89,12 +89,19 @@ jobs:
           DEPLOYMENT_NAME: ${{ inputs.projectName != '' && inputs.projectName || github.event.repository.name }}-${{ steps.get_version.outputs.build }}
       - name: Notify on failure
         if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          status: failure
-          fields: repo,author,eventName
-        env:
-          SLACK_WEBHOOK_URL: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
+          webhook: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#ff0000",
+                  "text": "Maven Central sync failed in `${{ github.repository }}` (event: `${{ github.event_name }}`, triggered by `${{ github.actor }}`).\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                }
+              ]
+            }
       - name: Exit with error
         if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
         run: exit 1

--- a/.github/workflows/npmjs.yaml
+++ b/.github/workflows/npmjs.yaml
@@ -160,13 +160,20 @@ jobs:
 
       - name: Notify on Failure
         if: ${{ failure() }}
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          status: failure
-          fields: repo,author,eventName
-          channel: ${{ inputs.slackChannel }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
+          webhook: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "channel": "${{ inputs.slackChannel }}",
+              "attachments": [
+                {
+                  "color": "#ff0000",
+                  "text": "npm publish failed in `${{ github.repository }}` (event: `${{ github.event_name }}`, triggered by `${{ github.actor }}`).\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                }
+              ]
+            }
 
       - name: Exit with Error
         if: ${{ failure() }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -96,13 +96,20 @@ jobs:
           print-hash: true
       - name: Notify on failure
         if: ${{ failure() }}
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          status: failure
-          fields: repo,author,eventName
-          channel: ${{ inputs.slackChannel }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
+          webhook: ${{ fromJSON(steps.secrets.outputs.vault).slack_webhook }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "channel": "${{ inputs.slackChannel }}",
+              "attachments": [
+                {
+                  "color": "#ff0000",
+                  "text": "PyPI publish failed in `${{ github.repository }}` (event: `${{ github.event_name }}`, triggered by `${{ github.actor }}`).\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                }
+              ]
+            }
       - name: Exit with error
         if: ${{ failure() }}
         run: exit 1


### PR DESCRIPTION
## Why

The reusable workflows in this repo are consumed via `workflow_call` by every SonarSource product release pipeline, so a deprecated action here propagates everywhere.

`8398a7/action-slack@v3.19.0` has two problems (surfaced in the [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781) cascade audit, tracked as [BUILD-11518](https://sonarsource.atlassian.net/browse/BUILD-11518)):

1. It runs on **Node 20** — GitHub deprecation enforced **2026-06-02**, full removal Fall 2026.
2. It is **upstream-deprecated** in favour of `slackapi/slack-github-action`.

So a version bump won't help; the action has to be replaced.

## Decision (AC #1)

Standardise on **`slackapi/slack-github-action@v3.0.3`** (Node 24) using the **incoming-webhook** technique that `main.yaml` already adopted in [BUILD-11049](https://sonarsource.atlassian.net/browse/BUILD-11049) (#391). This keeps one Slack action across the repo and reuses the existing Vault `slack_webhook` secret. Pinned by SHA per repo convention.

## What changed

| Workflow | Before | After |
|---|---|---|
| `maven-central.yaml` | `8398a7/action-slack` `status`+`fields`, `SLACK_WEBHOOK_URL` env | `slack-github-action@v3.0.3` `webhook` + `webhook-type: incoming-webhook` + JSON `payload` |
| `npmjs.yaml` | same + `channel: inputs.slackChannel` | v3 webhook payload, `"channel": inputs.slackChannel` preserved |
| `pypi.yaml` | same + `channel: inputs.slackChannel` | v3 webhook payload, `"channel": inputs.slackChannel` preserved |
| `main.yaml` | `slack-github-action@v2.1.1` (Node 20) | clean pin bump to `@v3.0.3`, inputs unchanged |

Notes:
- The new failure message is a red attachment containing **repo, event, triggering actor, and a link to the workflow run** (the old action auto-rendered `repo,author,eventName`; the replacement embeds the same info plus a run link).
- `maven-central` had **no** `channel` set before (posts to the webhook's default channel) — preserved by omitting `channel` in its payload.
- **No change to any input that downstream product pipelines pass** (`slackChannel`, `vaultAddr`, etc.), so this is not a breaking change for consumers — nothing to update in their workflows.

## Acceptance criteria ([BUILD-11518](https://sonarsource.atlassian.net/browse/BUILD-11518))

- [x] Decision recorded on which option is taken (option 1: `slackapi/slack-github-action@v3`)
- [x] Reusable workflows updated to the chosen replacement (all `8398a7/action-slack` removed; `main.yaml` moved off Node 20 v2)
- [ ] Smoke-test against one product release pipeline (see Test plan)
- [x] Docs: no downstream input semantics changed; README has no Slack-action references to update

## Test plan

These steps only run on **failure**, so testing means forcing a failure and checking Slack.

1. **Schema/CI:** `pre-commit` (incl. `check-github-workflows`) and the `Integration tests` workflow run on this PR. They validate structure but do **not** post to Slack (dry-run / dummy vault).
2. **Real Slack smoke test (recommended):** from a safe consumer — `sonar-dummy` (Maven) and/or `sonar-dummy-yarn` (npm) — run a release that points the reusable workflow at this branch and force the relevant job to fail (e.g. bad Maven Central/PyPI/npm credentials or a deliberately broken artifact), then confirm:
   - a message lands in the expected channel (`build` by default; webhook default channel for maven-central),
   - the step log shows **no Node 20 deprecation warning** and resolves `slack-github-action@v3.0.3`.
3. After merge, **tag/release** `gh-action_release` so product pipelines pick up the new reusable-workflow ref.

[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11518]: https://sonarsource.atlassian.net/browse/BUILD-11518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11049]: https://sonarsource.atlassian.net/browse/BUILD-11049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11518]: https://sonarsource.atlassian.net/browse/BUILD-11518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ