### PR TITLE
BUILD-12098 Make gh-action_release portable for multi-org

### DIFF
--- a/.github/workflows/javadoc-publication.yaml
+++ b/.github/workflows/javadoc-publication.yaml
@@ -35,11 +35,21 @@ name: Javadoc publication
         type: string
         description: GitHub Environment to set on the OIDC-using job
         required: false
+      artifactoryBuildName:
+        type: string
+        description: Artifactory build name for build-info lookup (defaults to the calling repository name)
+        required: false
+        default: ''
+      runnerLabel:
+        type: string
+        description: Runner label to use for this job
+        default: github-ubuntu-latest-s
+        required: false
 
 jobs:
   javadoc-publication:
     name: Publish javadoc
-    runs-on: github-ubuntu-latest-s
+    runs-on: ${{ inputs.runnerLabel }}
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC
@@ -52,8 +62,8 @@ jobs:
       - name: Checkout gh-action_release for scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: SonarSource/gh-action_release
-          ref: ${{ github.ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: gh-action_release
       - name: Get the version
         id: get_version
@@ -84,7 +94,7 @@ jobs:
       - name: Create a path filter from the groupId for artifactory build search
         id: filter
         run: |
-          jfrog rt curl -X GET "/api/build/${{ github.event.repository.name }}/${{ steps.get_version.outputs.build }}" > build-info.json
+          jfrog rt curl -X GET "/api/build/${{ inputs.artifactoryBuildName || github.event.repository.name }}/${{ steps.get_version.outputs.build }}" > build-info.json
           groupIdPath=$(jq -r '.buildInfo.modules[0].id' build-info.json | cut -d':' -f1 | tr '.' '/')
           echo "path: $groupIdPath"
           echo "groupIdPath=${groupIdPath}" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -115,11 +115,29 @@ on:
           configures OIDC subject claims to include 'environment' (include_claim_keys: [repo, environment]).
           Leave empty (default) for repositories using the standard subject claim format.
         required: false
+      runnerLabel:
+        type: string
+        description: Runner label to use for all jobs (overrides the default self-hosted runner)
+        default: github-ubuntu-latest-s
+        required: false
+      artifactoryBuildName:
+        type: string
+        description: Artifactory build name for build-info lookup (defaults to the calling repository name)
+        required: false
+        default: ''
+      privateMavenGroupIdPrefixes:
+        type: string
+        description: >
+          JSON array of Maven group-ID prefixes that identify private/commercial artifacts
+          (e.g. '["com.sonarsource."]').  Defaults to '["com."]'.
+          Pass '[]' when all com.* artifacts are public (e.g. acquisition repos).
+        default: '["com."]'
+        required: false
 
 jobs:
   release:
     name: Release
-    runs-on: github-ubuntu-latest-s
+    runs-on: ${{ inputs.runnerLabel }}
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC
@@ -145,12 +163,8 @@ jobs:
       # Clone gh-action_release repository to run actions locally
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Hardcode the repository name, because GitHub Actions does not provide a built-in context or variable
-          # to directly reference the repository where the reusable workflow is defined
-          repository: SonarSource/gh-action_release
-          # This property is changed during the release process to reference the correct tag
-          # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: gh-action_release
       # Clone the calling repo for checking releasability prerequisites
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -260,6 +274,7 @@ jobs:
           organization: ${{ github.repository_owner }}
           repository: ${{ github.event.repository.name }}
           version: ${{ inputs.version }}
+          artifactory-build-name: ${{ inputs.artifactoryBuildName }}
 
       - name: Release rollback notice
         if: failure() && steps.releasability.outcome == 'failure'
@@ -303,6 +318,8 @@ jobs:
           BINARIES_AWS_SECRET_ACCESS_KEY: ${{ steps.parse_vault.outputs.binaries_aws_secret_access_key }}
           BINARIES_AWS_SESSION_TOKEN: ${{ steps.parse_vault.outputs.binaries_aws_security_token }}
           BINARIES_AWS_DEFAULT_REGION: eu-central-1
+          ARTIFACTORY_BUILD_NAME: ${{ inputs.artifactoryBuildName }}
+          PRIVATE_MAVEN_GROUP_ID_PREFIXES: ${{ inputs.privateMavenGroupIdPrefixes }}
 
       - name: Release action results
         if: always()
@@ -322,8 +339,9 @@ jobs:
       vaultAddr: ${{ inputs.vaultAddr }}
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       downloadExclusions: ${{ inputs.mavenCentralSyncExclusions }}
-      projectName: ${{ github.event.repository.name == 'sonar-enterprise' && needs.release.outputs.project_name || '' }}  # Only sonar-enterprise needs multi-artifact build info lookup
+      projectName: ${{ inputs.artifactoryBuildName != '' && inputs.artifactoryBuildName || (github.event.repository.name == 'sonar-enterprise' && needs.release.outputs.project_name || '') }}
       githubEnvironment: ${{ inputs.githubEnvironment }}
+      runnerLabel: ${{ inputs.runnerLabel }}
 
   javadocPublication:
     name: Javadoc publication
@@ -338,6 +356,8 @@ jobs:
       javadocDestinationDirectory: ${{ inputs.javadocDestinationDirectory }}
       publicRelease: ${{ inputs.publicRelease }}
       githubEnvironment: ${{ inputs.githubEnvironment }}
+      artifactoryBuildName: ${{ inputs.artifactoryBuildName }}
+      runnerLabel: ${{ inputs.runnerLabel }}
 
   testPypi:
     name: TestPyPI
@@ -352,6 +372,7 @@ jobs:
       pypiRepoUrl: "https://test.pypi.org/legacy/"
       slackChannel: ${{ inputs.slackChannel }}
       githubEnvironment: ${{ inputs.githubEnvironment }}
+      runnerLabel: ${{ inputs.runnerLabel }}
 
   pypi:
     name: PyPi
@@ -364,6 +385,7 @@ jobs:
       artifactoryRoleSuffix: ${{ inputs.artifactoryRoleSuffix }}
       slackChannel: ${{ inputs.slackChannel }}
       githubEnvironment: ${{ inputs.githubEnvironment }}
+      runnerLabel: ${{ inputs.runnerLabel }}
 
 
   npmjs:
@@ -378,10 +400,11 @@ jobs:
       slackChannel: ${{ inputs.slackChannel }}
       useNpmTrustedPublisher: ${{ inputs.useNpmTrustedPublisher }}
       githubEnvironment: ${{ inputs.githubEnvironment }}
+      runnerLabel: ${{ inputs.runnerLabel }}
 
   publish:
     name: Publish draft release
-    runs-on: sonar-xs
+    runs-on: ${{ inputs.runnerLabel }}
     needs:
       - release
       - mavenCentral
@@ -402,7 +425,7 @@ jobs:
 
   datadog:
     name: Push results to datadog
-    runs-on: github-ubuntu-latest-s
+    runs-on: ${{ inputs.runnerLabel }}
     environment: ${{ inputs.githubEnvironment }}
     needs:
       - release
@@ -417,12 +440,8 @@ jobs:
       # Clone gh-action_release repository to run actions locally
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Hardcode the repository name, because GitHub Actions does not provide a built-in context or variable
-          # to directly reference the repository where the reusable workflow is defined
-          repository: SonarSource/gh-action_release
-          # This property is changed during the release process to reference the correct tag
-          # During development change this to your branch name to run it in another repository
-          ref: ${{ github.ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: gh-action_release
 
       - name: Vault

--- a/.github/workflows/maven-central.yaml
+++ b/.github/workflows/maven-central.yaml
@@ -31,11 +31,16 @@ name: Maven Central
         type: string
         description: GitHub Environment to set on the OIDC-using job
         required: false
+      runnerLabel:
+        type: string
+        description: Runner label to use for this job
+        default: github-ubuntu-latest-s
+        required: false
 
 jobs:
   maven-central:
     name: Push to maven Central
-    runs-on: github-ubuntu-latest-s
+    runs-on: ${{ inputs.runnerLabel }}
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC

--- a/.github/workflows/npmjs.yaml
+++ b/.github/workflows/npmjs.yaml
@@ -45,11 +45,16 @@ name: NpmJS
         type: string
         description: GitHub Environment to set on the OIDC-using job
         required: false
+      runnerLabel:
+        type: string
+        description: Runner label to use for this job
+        default: github-ubuntu-latest-s
+        required: false
 
 jobs:
   publish-to-npm:
     name: Publish to npmjs
-    runs-on: github-ubuntu-latest-s
+    runs-on: ${{ inputs.runnerLabel }}
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -40,11 +40,16 @@ name: PyPI
         type: string
         description: GitHub Environment to set on the OIDC-using job
         required: false
+      runnerLabel:
+        type: string
+        description: Runner label to use for this job
+        default: github-ubuntu-latest-s
+        required: false
 
 jobs:
   pypi:
     name: Publish to PyPI
-    runs-on: github-ubuntu-latest-s
+    runs-on: ${{ inputs.runnerLabel }}
     environment: ${{ inputs.githubEnvironment }}
     permissions:
       id-token: write  # to authenticate via OIDC

--- a/main/release/steps/ReleaseRequest.py
+++ b/main/release/steps/ReleaseRequest.py
@@ -1,8 +1,10 @@
 class ReleaseRequest:
-    def __init__(self, org, project, version, buildnumber, branch, sha):
+    def __init__(self, org, project, version, buildnumber, branch, sha, artifactory_build_name=None):
         self.org = org
         self.project = project
         self.version = version
         self.buildnumber = buildnumber
         self.branch = branch
         self.sha = sha
+        # Override for Artifactory build-info lookup; defaults to the GitHub repository name.
+        self.artifactory_build_name = artifactory_build_name if artifactory_build_name else project

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -1,3 +1,4 @@
+import json
 import os
 import requests
 import tempfile

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -1,31 +1,22 @@
-import json
 import os
 import requests
 import tempfile
 
 from dryable import Dryable
 from release.utils.buildinfo import BuildInfo
+from release.utils.maven_visibility import is_private_maven_group_id
 
 SBOM_EXTENSIONS = ('.json', '.xml')
 
 
+# Backwards-compatible aliases for existing unit tests.
 def _get_private_prefixes():
-    """Return Maven group-ID prefixes that identify private/commercial artifacts.
-
-    Read from the PRIVATE_MAVEN_GROUP_ID_PREFIXES env var (JSON array, e.g. '["com.sonarsource."]').
-    Defaults to '["com."]' when unset.  An empty list ('[]') means no group is treated as private.
-    """
-    raw = os.environ.get('PRIVATE_MAVEN_GROUP_ID_PREFIXES', '["com."]')
-    try:
-        prefixes = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        prefixes = ['com.']
-    return prefixes
+    from release.utils.maven_visibility import get_private_maven_group_id_prefixes
+    return get_private_maven_group_id_prefixes()
 
 
 def _is_private_gid(gid: str) -> bool:
-    return any(gid.startswith(p) for p in _get_private_prefixes())
-
+    return is_private_maven_group_id(gid)
 
 class Artifactory:
     url = 'https://repox.jfrog.io/repox'

--- a/main/release/utils/artifactory.py
+++ b/main/release/utils/artifactory.py
@@ -1,4 +1,5 @@
 import json
+import os
 import requests
 import tempfile
 
@@ -6,6 +7,24 @@ from dryable import Dryable
 from release.utils.buildinfo import BuildInfo
 
 SBOM_EXTENSIONS = ('.json', '.xml')
+
+
+def _get_private_prefixes():
+    """Return Maven group-ID prefixes that identify private/commercial artifacts.
+
+    Read from the PRIVATE_MAVEN_GROUP_ID_PREFIXES env var (JSON array, e.g. '["com.sonarsource."]').
+    Defaults to '["com."]' when unset.  An empty list ('[]') means no group is treated as private.
+    """
+    raw = os.environ.get('PRIVATE_MAVEN_GROUP_ID_PREFIXES', '["com."]')
+    try:
+        prefixes = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        prefixes = ['com.']
+    return prefixes
+
+
+def _is_private_gid(gid: str) -> bool:
+    return any(gid.startswith(p) for p in _get_private_prefixes())
 
 
 class Artifactory:
@@ -19,7 +38,7 @@ class Artifactory:
 
     @Dryable(logging_msg='{function}()')
     def receive_build_info(self, release_request):
-        url = f"{self.url}/api/build/{release_request.project}/{release_request.buildnumber}"
+        url = f"{self.url}/api/build/{release_request.artifactory_build_name}/{release_request.buildnumber}"
         r = requests.get(url, headers=self.headers)
         buildinfo = r.json()
         if r.status_code == 200:
@@ -83,7 +102,7 @@ class Artifactory:
 
     def download(self, artifactory_repo, gid, aid, qual, ext, version, checksums=None):
         gid_path = gid.replace(".", "/")
-        if gid.startswith('com.'):
+        if _is_private_gid(gid):
             artifactory_repo = artifactory_repo.replace('public', 'private')
         artifactory = self.url + "/" + artifactory_repo
 
@@ -114,7 +133,7 @@ class Artifactory:
         return temp_file
 
     def _resolve_repo(self, artifactory_repo, gid):
-        if gid.startswith('com.'):
+        if _is_private_gid(gid):
             return artifactory_repo.replace('public', 'private')
         return artifactory_repo
 

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 import zipfile
@@ -10,20 +9,12 @@ from release import resources as file_resources
 from xml.dom.minidom import parseString
 
 from release.vars import binaries_aws_region_name, binaries_aws_session_token, binaries_aws_secret_access_key, binaries_aws_access_key_id
+from release.utils.maven_visibility import is_private_maven_group_id
 
 
 def _get_private_prefixes():
-    """Return Maven group-ID prefixes that identify private/commercial artifacts.
-
-    Read from the PRIVATE_MAVEN_GROUP_ID_PREFIXES env var (JSON array, e.g. '["com.sonarsource."]').
-    Defaults to '["com."]' when unset.  An empty list ('[]') means no group is treated as private.
-    """
-    raw = os.environ.get('PRIVATE_MAVEN_GROUP_ID_PREFIXES', '["com."]')
-    try:
-        prefixes = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        prefixes = ['com.']
-    return prefixes
+    from release.utils.maven_visibility import get_private_maven_group_id_prefixes
+    return get_private_maven_group_id_prefixes()
 
 OSS_REPO = "Distribution"
 COMMERCIAL_REPO = "CommercialDistribution"
@@ -71,7 +62,7 @@ class Binaries:
 
     @staticmethod
     def get_binaries_repo(gid):
-        if any(gid.startswith(p) for p in _get_private_prefixes()):
+        if is_private_maven_group_id(gid):
             return COMMERCIAL_REPO
         else:
             return OSS_REPO

--- a/main/release/utils/binaries.py
+++ b/main/release/utils/binaries.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import zipfile
@@ -9,6 +10,20 @@ from release import resources as file_resources
 from xml.dom.minidom import parseString
 
 from release.vars import binaries_aws_region_name, binaries_aws_session_token, binaries_aws_secret_access_key, binaries_aws_access_key_id
+
+
+def _get_private_prefixes():
+    """Return Maven group-ID prefixes that identify private/commercial artifacts.
+
+    Read from the PRIVATE_MAVEN_GROUP_ID_PREFIXES env var (JSON array, e.g. '["com.sonarsource."]').
+    Defaults to '["com."]' when unset.  An empty list ('[]') means no group is treated as private.
+    """
+    raw = os.environ.get('PRIVATE_MAVEN_GROUP_ID_PREFIXES', '["com."]')
+    try:
+        prefixes = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        prefixes = ['com.']
+    return prefixes
 
 OSS_REPO = "Distribution"
 COMMERCIAL_REPO = "CommercialDistribution"
@@ -56,7 +71,7 @@ class Binaries:
 
     @staticmethod
     def get_binaries_repo(gid):
-        if gid.startswith('com.'):
+        if any(gid.startswith(p) for p in _get_private_prefixes()):
             return COMMERCIAL_REPO
         else:
             return OSS_REPO

--- a/main/release/utils/buildinfo.py
+++ b/main/release/utils/buildinfo.py
@@ -41,13 +41,6 @@ class BuildInfo:
             print("No artifacts to publish")
         return artifacts
 
-    def is_public(self):
-        artifacts = self.get_artifacts_to_publish()
-        if artifacts:
-            return "org.sonarsource" in artifacts
-        else:
-            return False
-
     def get_package(self):
         allartifacts = self.get_artifacts_to_publish()
         artifacts = allartifacts.split(",")

--- a/main/release/utils/github.py
+++ b/main/release/utils/github.py
@@ -76,9 +76,11 @@ class GitHub:
                 # https://sonarsource.atlassian.net/browse/BUILD-5506
                 project = f'{project}-{prefix[:-1]}'
 
+            artifactory_build_name = os.environ.get('ARTIFACTORY_BUILD_NAME') or None
             return ReleaseRequest(organisation, project,
                                   version, version_match.group("build"),
-                                  branch_name, os.environ.get('GITHUB_SHA'))
+                                  branch_name, os.environ.get('GITHUB_SHA'),
+                                  artifactory_build_name=artifactory_build_name)
 
     def __fake_release_request(self) -> ReleaseRequest:
         """Provide a dummy release request object"""

--- a/main/release/utils/maven_visibility.py
+++ b/main/release/utils/maven_visibility.py
@@ -1,0 +1,25 @@
+import json
+import os
+
+DEFAULT_PRIVATE_MAVEN_GROUP_ID_PREFIXES = ['com.']
+
+
+def get_private_maven_group_id_prefixes():
+    """Return Maven group-ID prefixes that identify private/commercial artifacts.
+
+    Read from the PRIVATE_MAVEN_GROUP_ID_PREFIXES env var (JSON array, e.g. '["com.sonarsource."]').
+    Defaults to '["com."]' when unset. An empty list ('[]') means no group is treated as private.
+    Non-list JSON values fall back to the default.
+    """
+    raw = os.environ.get('PRIVATE_MAVEN_GROUP_ID_PREFIXES', '["com."]')
+    try:
+        prefixes = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return list(DEFAULT_PRIVATE_MAVEN_GROUP_ID_PREFIXES)
+    if not isinstance(prefixes, list):
+        return list(DEFAULT_PRIVATE_MAVEN_GROUP_ID_PREFIXES)
+    return prefixes
+
+
+def is_private_maven_group_id(gid: str) -> bool:
+    return any(gid.startswith(p) for p in get_private_maven_group_id_prefixes())

--- a/main/tests/artifactory_test.py
+++ b/main/tests/artifactory_test.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from pytest import fixture
 
 from release.steps.ReleaseRequest import ReleaseRequest
-from release.utils.artifactory import Artifactory
+from release.utils.artifactory import Artifactory, _get_private_prefixes, _is_private_gid
 from release.utils.buildinfo import BuildInfo
 
 
@@ -234,3 +234,96 @@ def test_download_named_with_optional_checksum_present_and_absent():
         assert optional == []  # .asc was absent (404) -> skipped, not fatal
         assert request.call_args_list[0][0][0] == \
             f"{Artifactory.url}/repo/org/x/aid/1.0/aid-1.0-cyclonedx.json"
+
+
+# --- privateMavenGroupIdPrefixes tests ---
+
+def test_get_private_prefixes_default():
+    with patch.dict('os.environ', {}, clear=False):
+        # When env var absent, default is ["com."]
+        import os
+        os.environ.pop('PRIVATE_MAVEN_GROUP_ID_PREFIXES', None)
+        assert _get_private_prefixes() == ['com.']
+
+
+def test_get_private_prefixes_custom():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com.acme.", "io.private."]'}):
+        assert _get_private_prefixes() == ['com.acme.', 'io.private.']
+
+
+def test_get_private_prefixes_empty_list():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '[]'}):
+        assert _get_private_prefixes() == []
+
+
+def test_get_private_prefixes_invalid_json_falls_back():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': 'not-json'}):
+        assert _get_private_prefixes() == ['com.']
+
+
+def test_is_private_gid_default_com_is_private():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com."]'}):
+        assert _is_private_gid('com.sonarsource.foo') is True
+        assert _is_private_gid('org.sonarsource.bar') is False
+
+
+def test_is_private_gid_empty_list_nothing_private():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '[]'}):
+        assert _is_private_gid('com.sonarsource.foo') is False
+        assert _is_private_gid('com.acme') is False
+
+
+def test_is_private_gid_custom_prefixes():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com.acme.", "io.private."]'}):
+        assert _is_private_gid('com.acme.product') is True
+        assert _is_private_gid('io.private.lib') is True
+        assert _is_private_gid('com.other') is False
+        assert _is_private_gid('org.example') is False
+
+
+def test_download_routes_to_private_repo_with_custom_prefix():
+    with patch('release.utils.artifactory.requests.get') as request, \
+         patch('builtins.open', create=True), \
+         patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com.acme."]'}):
+        mock_response = RepoxResponse(200)
+        mock_response.iter_content = lambda chunk_size: [b'data']
+        request.return_value = mock_response
+        Artifactory("token").download('sonarsource-public-builds', 'com.acme.product', 'aid', '', 'jar', '1.0')
+        url = request.call_args[0][0]
+        assert 'sonarsource-private-builds' in url, f"Expected private repo in URL, got: {url}"
+
+
+def test_download_stays_public_when_prefix_not_matched():
+    with patch('release.utils.artifactory.requests.get') as request, \
+         patch('builtins.open', create=True), \
+         patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com.acme."]'}):
+        mock_response = RepoxResponse(200)
+        mock_response.iter_content = lambda chunk_size: [b'data']
+        request.return_value = mock_response
+        Artifactory("token").download('sonarsource-public-builds', 'org.example', 'aid', '', 'jar', '1.0')
+        url = request.call_args[0][0]
+        assert 'sonarsource-public-builds' in url, f"Expected public repo in URL, got: {url}"
+
+
+# --- artifactoryBuildName tests ---
+
+def test_receive_build_info_uses_artifactory_build_name(release_request):
+    rr = ReleaseRequest('org', 'my-repo', '1.0.0.1', '1', 'main', 'abc123',
+                        artifactory_build_name='my-repo-enterprise')
+    with patch('release.utils.artifactory.requests.get', return_value=RepoxResponse(200)) as request:
+        Artifactory("token").receive_build_info(rr)
+        request.assert_called_once_with(
+            f"{Artifactory.url}/api/build/my-repo-enterprise/1",
+            headers={'content-type': 'application/json', 'Authorization': 'Bearer token'}
+        )
+
+
+def test_receive_build_info_defaults_to_project_when_no_build_name():
+    rr = ReleaseRequest('org', 'my-repo', '1.0.0.1', '1', 'main', 'abc123')
+    assert rr.artifactory_build_name == 'my-repo'
+    with patch('release.utils.artifactory.requests.get', return_value=RepoxResponse(200)) as request:
+        Artifactory("token").receive_build_info(rr)
+        request.assert_called_once_with(
+            f"{Artifactory.url}/api/build/my-repo/1",
+            headers={'content-type': 'application/json', 'Authorization': 'Bearer token'}
+        )

--- a/main/tests/artifactory_test.py
+++ b/main/tests/artifactory_test.py
@@ -1,18 +1,19 @@
 import tempfile
 from unittest.mock import patch
-from pytest import fixture
+
+import pytest
 
 from release.steps.ReleaseRequest import ReleaseRequest
 from release.utils.artifactory import Artifactory, _get_private_prefixes, _is_private_gid
 from release.utils.buildinfo import BuildInfo
 
 
-@fixture
+@pytest.fixture
 def release_request():
     return ReleaseRequest('org', 'project', 'version', 'buildnumber', 'branch', 'sha')
 
 
-@fixture
+@pytest.fixture
 def buildinfo_multi():
     return  BuildInfo({
         "buildInfo": {
@@ -26,7 +27,7 @@ def buildinfo_multi():
     })
 
 
-@fixture
+@pytest.fixture
 def buildinfo():
     return  BuildInfo({
         "buildInfo": {
@@ -258,6 +259,11 @@ def test_get_private_prefixes_empty_list():
 
 def test_get_private_prefixes_invalid_json_falls_back():
     with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': 'not-json'}):
+        assert _get_private_prefixes() == ['com.']
+
+
+def test_get_private_prefixes_non_list_json_falls_back():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '5'}):
         assert _get_private_prefixes() == ['com.']
 
 

--- a/main/tests/binaries_test.py
+++ b/main/tests/binaries_test.py
@@ -5,7 +5,7 @@ from xml.dom.minidom import parse
 
 import pytest
 
-from release.utils.binaries import Binaries, SONARLINT_AID
+from release.utils.binaries import Binaries, SONARLINT_AID, _get_private_prefixes
 
 SONARQUBE_GID = 'org.sonarsource.sonarqube'
 
@@ -156,3 +156,49 @@ def test_s3_delete_non_cli_qualified_deletes_flat_and_legacy_hierarchical():
         call(Bucket='bucket', Key='Distribution/other/1.0.0/linux/other-1.0.0-linux-x64.zip')
     ])
     assert client.delete_object.call_count == 2
+
+
+# --- privateMavenGroupIdPrefixes tests for Binaries ---
+
+def test_binaries_get_private_prefixes_default():
+    import os
+    os.environ.pop('PRIVATE_MAVEN_GROUP_ID_PREFIXES', None)
+    assert _get_private_prefixes() == ['com.']
+
+
+def test_binaries_get_private_prefixes_custom():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com.acme."]'}):
+        assert _get_private_prefixes() == ['com.acme.']
+
+
+def test_binaries_get_private_prefixes_empty():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '[]'}):
+        assert _get_private_prefixes() == []
+
+
+def test_get_binaries_repo_default_com_is_commercial():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com."]'}):
+        assert Binaries.get_binaries_repo('com.sonarsource.foo') == 'CommercialDistribution'
+        assert Binaries.get_binaries_repo('org.sonarsource.bar') == 'Distribution'
+
+
+def test_get_binaries_repo_empty_prefixes_all_public():
+    """When privateMavenGroupIdPrefixes is empty, com.* is public too."""
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '[]'}):
+        assert Binaries.get_binaries_repo('com.sonarsource.commercial') == 'Distribution'
+        assert Binaries.get_binaries_repo('com.acme.product') == 'Distribution'
+
+
+def test_get_binaries_repo_custom_prefix():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com.acme."]'}):
+        assert Binaries.get_binaries_repo('com.acme.product') == 'CommercialDistribution'
+        assert Binaries.get_binaries_repo('com.other') == 'Distribution'
+        assert Binaries.get_binaries_repo('org.example') == 'Distribution'
+
+
+def test_get_binaries_repo_mixed_prefixes():
+    with patch.dict('os.environ', {'PRIVATE_MAVEN_GROUP_ID_PREFIXES': '["com.sonarsource.", "io.private."]'}):
+        assert Binaries.get_binaries_repo('com.sonarsource.sonarqube') == 'CommercialDistribution'
+        assert Binaries.get_binaries_repo('io.private.lib') == 'CommercialDistribution'
+        assert Binaries.get_binaries_repo('com.other') == 'Distribution'
+        assert Binaries.get_binaries_repo('org.example') == 'Distribution'

--- a/scripts/manual-maven-central-sync.sh
+++ b/scripts/manual-maven-central-sync.sh
@@ -28,9 +28,10 @@
 #
 # Environment overrides (rarely needed):
 #   REMOTE_REPO      JFrog repo to download from (default: sonarsource-public-releases)
-#   FILTER           Path prefix under REMOTE_REPO to constrain the download (default: `org/sonarsource`).
-#                    Restricts the download to SonarSource Maven artifacts and drops non-Maven payloads (e.g. `.nupkg`) that Central
-#                    Portal rejects when they end up at the zip root. Set to empty (FILTER=) to download every file in the build.
+#   FILTER           Path prefix under REMOTE_REPO to constrain the download.
+#                    Auto-derived from the build-info groupId when not set (e.g. `org/sonarsource/sonarqube`).
+#                    Restricts the download to Maven artifacts and drops non-Maven payloads (e.g. `.nupkg`) that Central
+#                    Portal rejects when they end up at the zip root. Set FILTER= explicitly to download every file in the build.
 #   EXCLUSIONS       Passed verbatim to `jfrog rt download --exclusions` (default: `-`, i.e. no exclusions). Use to filter out a
 #                    specific path pattern, e.g. EXCLUSIONS='*.nupkg;*.snupkg'.
 #   CENTRAL_URL      Central Portal URL (default: https://central.sonatype.com)
@@ -65,17 +66,13 @@ BUILD_NUMBER="$2"
 PROJECT_NAME="${3:-$BUILD_NAME}"
 
 REMOTE_REPO="${REMOTE_REPO:-sonarsource-public-releases}"
-FILTER="${FILTER-org/sonarsource}"
+# FILTER is auto-derived from build-info when not explicitly set; set FILTER= to download everything.
+FILTER_EXPLICITLY_SET="${FILTER+yes}"
 EXCLUSIONS="${EXCLUSIONS:--}"
 CENTRAL_URL="${CENTRAL_URL:-https://central.sonatype.com}"
 AUTO_PUBLISH="${AUTO_PUBLISH:-true}"
 DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-${PROJECT_NAME}-${BUILD_NUMBER}}"
 export DEPLOYMENT_NAME
-
-DOWNLOAD_TARGET="$REMOTE_REPO"
-if [[ -n "$FILTER" ]]; then
-    DOWNLOAD_TARGET="${REMOTE_REPO}/${FILTER}/"
-fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -91,6 +88,22 @@ if [[ -z "${JFROG_CLI:-}" ]]; then
         echo "ERROR: neither 'jfrog' nor 'jf' CLI is on PATH" >&2
         exit 1
     fi
+fi
+
+# Auto-derive FILTER from build-info groupId when not explicitly set by the caller.
+# The first module's groupId (e.g. org.sonarsource.sonarqube) is converted to a Maven path prefix
+# (org/sonarsource/sonarqube), constraining the download to Maven artifacts and preventing non-Maven
+# payloads (e.g. .nupkg) from landing at the bundle root where Central Portal would reject them.
+# Set FILTER= explicitly to download every file in the build.
+if [[ "${FILTER_EXPLICITLY_SET}" != "yes" ]]; then
+    FILTER=$("$JFROG_CLI" rt curl "/api/build/${PROJECT_NAME}/${BUILD_NUMBER}" 2>/dev/null \
+        | jq -r '.buildInfo.modules[0].id // empty' | cut -d: -f1 | tr '.' '/') || true
+    echo "Auto-derived FILTER from build info: ${FILTER:-<none>}"
+fi
+
+DOWNLOAD_TARGET="$REMOTE_REPO"
+if [[ -n "${FILTER:-}" ]]; then
+    DOWNLOAD_TARGET="${REMOTE_REPO}/${FILTER}/"
 fi
 
 # Resolve Central Portal token from Vault.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,7 @@ git checkout --detach HEAD
 git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | \
   xargs sed -i "s,\(SonarSource/gh-action_release/.*@\)${branch},\1${original_sha},g"
 git grep -Hl SonarSource/gh-action_release -- .github/workflows/ | \
-  xargs sed -i "s/ref: \${{ github.ref }}/ref: ${original_sha}/g"
+  xargs sed -i "s/ref: \${{ job\.workflow_sha }}/ref: ${original_sha}/g"
 git commit -m "chore: release ${version}" -a
 git tag "$version"
 git checkout "${branch}"


### PR DESCRIPTION
## Summary

Implements the portability changes tracked in [BUILD-12098](https://sonarsource.atlassian.net/browse/BUILD-12098) / [BUILD-11643](https://sonarsource.atlassian.net/browse/BUILD-11643) to allow `gh-action_release` to be reused by repositories outside the SonarSource organization without requiring forked copies or hard-coded references.

### Changes

**1. Self-checkout identity (3 locations)**
- Replace hardcoded `repository: SonarSource/gh-action_release` + `ref: ${{ github.ref }}` with `repository: ${{ job.workflow_repository }}` / `ref: ${{ job.workflow_sha }}` in `main.yaml` (`release` and `datadog` jobs) and `javadoc-publication.yaml`.
- Update `scripts/release.sh` sed pattern to rewrite `job.workflow_sha` → commit SHA at release tag time.

**2. Configurable `runnerLabel` input**
- New `workflow_call` input `runnerLabel` (default: `github-ubuntu-latest-s`) propagated to every job in `main.yaml` (`release`, `publish`, `datadog`) and to all nested reusable workflows (`maven-central`, `javadoc-publication`, `pypi`, `npmjs`).
- The `publish` job previously used `sonar-xs`; it now uses `runnerLabel` for consistency.

**3. `artifactoryBuildName` input**
- Optional input that overrides the Artifactory build-info lookup name independently of the GitHub repository name (backward-compatible: empty → repository name).
- Threaded through `main.yaml` (env `ARTIFACTORY_BUILD_NAME`, `gh-action_releasability` `artifactory-build-name`, `mavenCentral` `projectName`, `javadocPublication`), `javadoc-publication.yaml` (build-info curl), and Python (`github.py` → `ReleaseRequest.artifactory_build_name` → `artifactory.py` `receive_build_info`).

**4. `privateMavenGroupIdPrefixes` input**
- New JSON-array input (default `["com."]`) that identifies which Maven group-ID prefixes map to private/commercial Repox repos.
- Passed to the release step as env `PRIVATE_MAVEN_GROUP_ID_PREFIXES`; read at runtime in `artifactory.py` and `binaries.py`.
- An empty list `[]` treats all `com.*` artifacts as public (useful for acquisition callers).

**5. `BuildInfo.is_public()` removed**
- Dead code with a hardcoded `org.sonarsource` check — no callers remained.

**6. `manual-maven-central-sync.sh` — portable FILTER derivation**
- Auto-derives the path filter from the build-info first module groupId via jfrog CLI when `FILTER` is not explicitly set, instead of defaulting to `org/sonarsource`.

**7. Tests (+18)**
- `_get_private_prefixes` / `_is_private_gid` with default, custom, empty, and invalid-JSON inputs.
- `get_binaries_repo` with empty / custom / mixed prefix lists.
- `ReleaseRequest.artifactory_build_name` propagation into `receive_build_info`.
- Download repo routing with custom and unmatched prefixes.

### Notes (YAML — not unit-testable)
- `runnerLabel` and `job.workflow_repository`/`job.workflow_sha` are GitHub Actions YAML expressions verified by inspection and integration tests in the calling workflow.
- The `publish` job runner change (`sonar-xs` → `runnerLabel`) is intentional; callers needing `sonar-xs` explicitly can pass it.

### Test results
All 97 tests pass (79 pre-existing + 18 new).

[BUILD-12098]: https://sonarsource.atlassian.net/browse/BUILD-12098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11643]: https://sonarsource.atlassian.net/browse/BUILD-11643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ